### PR TITLE
Makefile: Fix the scst-rpm build

### DIFF
--- a/scst.spec.in
+++ b/scst.spec.in
@@ -125,7 +125,7 @@ Authors:
 export PREFIX=%{_prefix}
 export BUILD_2X_MODULE=y CONFIG_SCSI_QLA_FC=y CONFIG_SCSI_QLA2XXX_TARGET=y
 make 2release
-for d in scst fcst iscsi-scst qla2x00t/qla2x00-target scst_local srpt; do
+for d in scst fcst iscsi-scst qla2x00t-32gbit/qla2x00-target scst_local srpt; do
     %{make} -C $d
 done
 
@@ -137,7 +137,7 @@ export BUILD_2X_MODULE=y CONFIG_SCSI_QLA_FC=y CONFIG_SCSI_QLA2XXX_TARGET=y
 for d in scst; do
     DESTDIR=%{buildroot} %{make} -C $d install
 done
-for d in fcst iscsi-scst qla2x00t/qla2x00-target scst_local srpt; do
+for d in fcst iscsi-scst qla2x00t-32gbit/qla2x00-target scst_local srpt; do
     DESTDIR=%{buildroot} INSTALL_MOD_PATH=%{buildroot} %{make} -C $d install
 done
 # Set the executable bit such that /usr/lib/rpm/find-debuginfo.sh can find the


### PR DESCRIPTION
Fixes: 1cfa1e7f87b2 ("Makefile: switch to qla-32gbit by default")