### PR TITLE
vdisk_fileio, async mode: Switch from kvec to bvec

### DIFF
--- a/scst/include/scst.h
+++ b/scst/include/scst.h
@@ -5134,6 +5134,23 @@ static inline int scst_get_buf_count(struct scst_cmd *cmd)
 }
 
 /*
+ * Returns approximate higher rounded buffers count in pages
+ */
+static inline int scst_get_buf_page_count(struct scst_cmd *cmd)
+{
+	struct scatterlist *sg;
+	int page_cnt = 0, i;
+
+	if (unlikely(cmd->sg_cnt == 0))
+		return 1;
+
+	for (i = 0, sg = cmd->sg; i < cmd->sg_cnt; i++, sg = sg_next_inline(sg))
+		page_cnt += PAGE_ALIGN(sg->offset + sg->length) >> PAGE_SHIFT;
+
+	return page_cnt;
+}
+
+/*
  * Returns approximate higher rounded buffers count that
  * scst_get_out_buf_[first|next]() return.
  */

--- a/scst/src/dev_handlers/scst_vdisk.c
+++ b/scst/src/dev_handlers/scst_vdisk.c
@@ -3224,7 +3224,7 @@ static void fileio_async_complete(struct kiocb *iocb, long ret
 		}
 	}
 	cmd->completed = 1;
-	cmd->scst_cmd_done(cmd, SCST_CMD_STATE_DEFAULT, SCST_CONTEXT_SAME);
+	cmd->scst_cmd_done(cmd, SCST_CMD_STATE_DEFAULT, scst_estimate_context());
 }
 
 static enum compl_status_e fileio_exec_async(struct vdisk_cmd_params *p)


### PR DESCRIPTION
fileio_exec_async() for fileio devices with o_direct flag triggers
the following Linux direct_io datapath:
- fileio_exec_async()      -- ... --> iomap_dio_bio_actor()
- iomap_dio_bio_actor()    -- ... --> bio_iov_iter_get_pages()
- bio_iov_iter_get_pages() -- ... --> iov_iter_get_pages()
- iov_iter_get_pages() returns -EFAULT

iov_iter_get_pages() only handles iovec and bvec iterators.
Its kvec hanlding always return -EFAULT.

We cannot use iovec because calling iov_iter_init() for iovec
from the kernel context initializes iov_iter as ITER_KVEC.

Thus, use bvecs for fileio async direct IO.

Reported-by: Lu Chang