### PR TITLE
scst_lib: Fix use of uninitialized ini_unchecked_isa_dma

### DIFF
--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -5259,7 +5259,7 @@ static int scst_alloc_add_tgt_dev(struct scst_session *sess,
 {
 	int res = 0;
 	struct scst_tgt_template *tgtt = sess->tgt->tgtt;
-	int ini_sg, ini_unchecked_isa_dma, ini_use_clustering;
+	int ini_sg, ini_unchecked_isa_dma = 0, ini_use_clustering;
 	struct scst_tgt_dev *tgt_dev;
 	struct scst_device *dev = acg_dev->dev;
 	struct list_head *head;


### PR DESCRIPTION
The ini_unchecked_isa_dma in the scst_alloc_add_tgt_dev() is used
as an uninitialized variable for kernel versions since v5.13.

Fixes: 2a775c42 ("scst: Port to Linux kernel v5.13")

Detected by smatch.