### PR TITLE
scst_vdisk: Always mark manually set thin_provisioned sysfs attribute…

### DIFF
--- a/scst/src/dev_handlers/scst_vdisk.c
+++ b/scst/src/dev_handlers/scst_vdisk.c
@@ -7944,9 +7944,7 @@ static ssize_t vdisk_sysfs_tp_show(struct kobject *kobj,
 	virt_dev = dev->dh_priv;
 
 	pos = sprintf(buf, "%d\n%s", virt_dev->thin_provisioned,
-		      virt_dev->thin_provisioned_manually_set &&
-		      (virt_dev->thin_provisioned !=
-		       virt_dev->dev_thin_provisioned) ?
+		      virt_dev->thin_provisioned_manually_set ?
 		      SCST_SYSFS_KEY_MARK "\n" : "");
 
 	TRACE_EXIT_RES(pos);


### PR DESCRIPTION
…s as [key]

The thin_provisioned != dev_thin_provisioned condition isn't the best way
for marking manually set thin_provisioned attribute.

```
-----------------------------------
| thin_prov | dev_thin_prov | key |
----------------------------------
|    0, 1   |      0        | No  |
-----------------------------------
|     1     |      1        | No  |
-----------------------------------
|     0     |      1        | Yes |
-----------------------------------
```
The thin_prov=1, dev_thin_prov=0 case leads to thin_prov will be set to
0 due to internal checking.

So, it's possible to see the value of the thin_provisioned attribute
via scstadmin only in the one case (3 row).

It's especially unclear for the fileio devices, because they support
thin provisioning only when the corresponding attribute is manually set.

Thus, to clarify the using of the thin_provisioned attribute always
display it when manually set.