### PR TITLE
iscsi-scstd: Allow to specify multiple addresses the server should listen on

### DIFF
--- a/iscsi-scst/doc/manpages/iscsi-scstd.8
+++ b/iscsi-scst/doc/manpages/iscsi-scstd.8
@@ -42,8 +42,8 @@ Act as a normal application which uses a console.
 .BI \-g\  GID ,\ \-\-gid= GID
 Specify running group id, default is current gid.
 .TP
-.BI \-a\  address ,\ \-\-address= address
-Specify on which local address the server should listen, default is any.
+.BI \-a\  address\ ... ,\ \-\-address= address\ ...
+Specify on which space-separated list of local addresses the server should listen, default is any.
 .TP
 .BI \-p\  port ,\ \-\-port= port
 Specify on which port the server should listen, default is 3260.

--- a/iscsi-scst/usr/iscsid.h
+++ b/iscsi-scst/usr/iscsid.h
@@ -224,7 +224,8 @@ struct target {
 extern int ctrl_fd;
 extern int conn_blocked;
 
-#define LISTEN_MAX		8
+#define ADDR_MAX		32
+#define LISTEN_MAX		32
 #define INCOMING_MAX		256
 
 enum {


### PR DESCRIPTION
Add the opportunity to globally specify multiple addresses, which
iSCSI/iSER portal will listen on.

There is a way to specify the addresses for a target, on which
portals it will be available, using the allowed_portal parameter.

There is also a way to set this globally via the iscsi-scstd
--address parameter. The problem is that the last option allows
you to specify only one local address. So extend this functionality
to specify more then one address.

Also increase the maximum number of listening addresses to 32.

Signed-off-by: Aleksandr Dyadyushkin <alextalker@ya.ru>