### PR TITLE
qla2x00t-32gbit: Restore support for sysfs hw_target attribute

### DIFF
--- a/qla2x00t-32gbit/qla2x00-target/scst_qla2xxx.c
+++ b/qla2x00t-32gbit/qla2x00-target/scst_qla2xxx.c
@@ -925,7 +925,16 @@ static ssize_t sqa_version_show(struct kobject *kobj,
 static ssize_t sqa_hw_target_show(struct kobject *kobj,
 				  struct kobj_attribute *attr, char *buf)
 {
-	return sprintf(buf, "%d\n", 1);
+	struct scst_tgt *scst_tgt;
+	struct sqa_scst_tgt *sqa_tgt;
+	struct qla_tgt *tgt;
+
+	scst_tgt = container_of(kobj, struct scst_tgt, tgt_kobj);
+	sqa_tgt = scst_tgt_get_tgt_priv(scst_tgt);
+
+	tgt = sqa_tgt->qla_tgt;
+
+	return sprintf(buf, "%d\n", (tgt->vha->vp_idx == 0) ? 1 : 0);
 }
 
 static ssize_t sqa_node_name_show(struct kobject *kobj,


### PR DESCRIPTION
For the old qla2x00 driver, the hw_target attribute allows you to
distinguish hardware and virtual targets.

But for the new qla2x00t-32gbit driver, this attribute turned out
to be broken. Regardless of whether it is a hardware or virtual target,
this attribute is created for that target and always returns 1.

Restore this broken functionality by returning 1 for the hardware target
and 0 otherwise.