### PR TITLE
qla2x00t-32gbit: Fix crash during deregistering an NPIV port

### DIFF
--- a/qla2x00t-32gbit/qla2x00-target/qla_tgt.c
+++ b/qla2x00t-32gbit/qla2x00-target/qla_tgt.c
@@ -47,9 +47,10 @@
 
 size_t qlt_add_vtarget(u64 port_name, u64 node_name, u64 parent_host)
 {
+	struct fc_vport *vport;
 	struct Scsi_Host *shost = NULL;
+	scsi_qla_host_t *vha = NULL, *npiv_vha;
 	struct qla_tgt *tgt;
-	scsi_qla_host_t *vha = NULL;
 	struct fc_vport_identifiers vid;
 	uint8_t parent_wwn[WWN_SIZE];
 
@@ -78,8 +79,14 @@ size_t qlt_add_vtarget(u64 port_name, u64 node_name, u64 parent_host)
 	vid.disable = false;            /* always enabled */
 
 	/* We only allow support on Channel 0 !!! */
-	if (!fc_vport_create(shost, 0, &vid))
+	vport = fc_vport_create(shost, 0, &vid);
+	if (!vport) {
+		pr_err("fc_vport_create failed for qla2xxx_npiv\n");
 		return -EINVAL;
+	}
+
+	npiv_vha = (struct scsi_qla_host *) vport->dd_data;
+	scsi_host_get(npiv_vha->host);
 
 	return 0;
 }

--- a/qla2x00t-32gbit/qla2x00-target/scst_qla2xxx.c
+++ b/qla2x00t-32gbit/qla2x00-target/scst_qla2xxx.c
@@ -2175,7 +2175,6 @@ static void __exit sqa_exit(void)
 				vha->host_no);
 
 			qlt_stop_phase1(sqa_tgt->qla_tgt);
-			scst_unregister_target(sqa_tgt->scst_tgt);
 			qlt_del_vtarget(wwn_to_u64(vha->port_name));
 		}
 	}


### PR DESCRIPTION
NPIV port deregistering processing is different from physical port
processing. We use the same handling for both of them, which causes
the crash when it's an NPIV port. Hence separate the common processing
logic depending on the type of port.

Reported-by: Rob Turk <robtu@rtist.nl>