### PR TITLE
github: Change mail server for mail notification action

### DIFF
--- a/.github/workflows/mail_notification.yml
+++ b/.github/workflows/mail_notification.yml
@@ -64,7 +64,7 @@ jobs:
         uses: dawidd6/action-send-mail@v3
         with:
           # Required mail server address:
-          server_address: smtp.gmail.com
+          server_address: smtp.yandex.com
           # Required mail server port:
           server_port: 465
           # Optional (recommended): mail server username:


### PR DESCRIPTION
Google no longer support the use of third-party apps or devices which
ask you to sign in to your Google Account using only your username and
password. This causes problems when using github mail notification action
to send SCST patches. Hence, change the Google mail server to an another one.