### PR TITLE
qla2x00t-32gbit: Change preferred context for scst_cmd_init_done()

### DIFF
--- a/qla2x00t-32gbit/qla2x00-target/scst_qla2xxx.c
+++ b/qla2x00t-32gbit/qla2x00-target/scst_qla2xxx.c
@@ -487,8 +487,7 @@ static int sqa_qla2xxx_handle_cmd(scsi_qla_host_t *vha,
 	      vha->host_no, vha->vp_idx, cmd, cmd->atio.u.isp24.exchange_addr,
 	      scst_cmd_get_queue_type(cmd->scst_cmd));
 
-	/* we're being call by wq, so do direct */
-	scst_cmd_init_done(cmd->scst_cmd, SCST_CONTEXT_DIRECT);
+	scst_cmd_init_done(cmd->scst_cmd, scst_work_context);
 
 out:
 	TRACE_EXIT_RES(res);


### PR DESCRIPTION
Calling scst_cmd_init_done() with SCST_CONTEXT_DIRECT from
sqa_qla2xxx_handle_cmd() cause a SCST READ commands to stall for
scst_user devices.

The problem is that scst_user devices use udev_cmd_threads for processing
SCST commands, so it's necessary to call the scst_user dev handler
callbacks from the SCST_CONTEXT_THREAD context.

For write commands, this is already done because scst_rx_data() always
processes commands with a THREAD context. But for READ commands, it
depends on passing the preferred context value to scst_cmd_init_done().

So pass the SCST_CONTEXT_THREAD or SCST_CONTEXT_TASKLET to
scst_cmd_init_done(). SCST_CONTEXT_TASKLET would also work, because
the context optimization in scst_init_cmd() will still set SCST_CONTEXT_THREAD
for READ commands.

Reported-by: Eitan Cohen <eitancohen456@gmail.com>