### PR TITLE
qla2x00t: Remove pci-dma-compat wrapper API

### DIFF
--- a/qla2x00t/qla2x00-target/qla2x00t.c
+++ b/qla2x00t/qla2x00-target/qla2x00t.c
@@ -2346,7 +2346,7 @@ static int q2t_pci_map_calc_cnt(struct q2t_prm *prm)
 	sBUG_ON(prm->cmd->sg_cnt == 0);
 
 	prm->sg = prm->cmd->sg;
-	prm->seg_cnt = pci_map_sg(prm->tgt->vha->hw->pdev, prm->cmd->sg,
+	prm->seg_cnt = dma_map_sg(&prm->tgt->vha->hw->pdev->dev, prm->cmd->sg,
 		prm->cmd->sg_cnt, prm->cmd->dma_data_direction);
 	if (unlikely(prm->seg_cnt == 0))
 		goto out_err;
@@ -2376,7 +2376,7 @@ out_err:
 static inline void q2t_unmap_sg(scsi_qla_host_t *vha, struct q2t_cmd *cmd)
 {
 	EXTRACHECKS_BUG_ON(!cmd->sg_mapped);
-	pci_unmap_sg(vha->hw->pdev, cmd->sg, cmd->sg_cnt,
+	dma_unmap_sg(&vha->hw->pdev->dev, cmd->sg, cmd->sg_cnt,
 	    cmd->dma_data_direction);
 	cmd->sg_mapped = 0;
 }

--- a/qla2x00t/qla_os.c
+++ b/qla2x00t/qla_os.c
@@ -1515,7 +1515,7 @@ qla2x00_config_dma_addressing(struct qla_hw_data *ha)
 	if (!dma_set_mask(&ha->pdev->dev, DMA_BIT_MASK(64))) {
 		/* Any upper-dword bits set? */
 		if (MSD(dma_get_required_mask(&ha->pdev->dev)) &&
-		    !pci_set_consistent_dma_mask(ha->pdev, DMA_BIT_MASK(64))) {
+		    !dma_set_coherent_mask(&ha->pdev->dev, DMA_BIT_MASK(64))) {
 			/* Ok, a 64bit DMA mask is applicable. */
 			ha->enable_64bit_addressing = 1;
 			ha->isp_ops->calc_req_entries = qla2x00_calc_iocbs_64;
@@ -1525,7 +1525,7 @@ qla2x00_config_dma_addressing(struct qla_hw_data *ha)
 	}
 
 	dma_set_mask(&ha->pdev->dev, DMA_BIT_MASK(32));
-	pci_set_consistent_dma_mask(ha->pdev, DMA_BIT_MASK(32));
+	dma_set_coherent_mask(&ha->pdev->dev, DMA_BIT_MASK(32));
 }
 
 static void


### PR DESCRIPTION
The legacy API wrappers in include/linux/pci-dma-compat.h should go away as
they create unnecessary midlayering for include/linux/dma-mapping.h API.
Instead use dma-mapping.h API directly.

This patch fixes build for linux kernel v5.18.