### PR TITLE
mailmap: Update Gleb Chesnokov's email address

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -14,3 +14,4 @@ Bart Van Assche <bvanassche@acm.org> Bart Van Assche <bart.vanassche@sandisk.com
 Bart Van Assche <bvanassche@acm.org> Bart Van Assche <bart.vanassche@wdc.com>
 Bart Van Assche <bvanassche@acm.org> Bart Van Assche <bvanassche@users.noreply.github.com>
 Gleb Chesnokov <Chesnokov.G@raidix.com> Chesnokov Gleb <Chesnokov.G@raidix.com>
+Gleb Chesnokov <gleb.chesnokov@scst.dev> <Chesnokov.G@raidix.com>


### PR DESCRIPTION
I have created a new dedicated email address for SCST. So add
information about it.

New email: gleb.chesnokov@scst.dev