### PR TITLE
Port to Linux kernel v6.0

### DIFF
--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -773,6 +773,22 @@ static inline void kvfree(void *addr)
 }
 #endif
 
+/* <linux/shrinker.h> */
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
+/*
+ * See also commit e33c267ab70d ("mm: shrinkers: provide shrinkers with
+ * names") # v6.0.
+ */
+static inline
+int register_shrinker_backport(struct shrinker *shrinker, const char *fmt, ...)
+{
+	return register_shrinker(shrinker);
+}
+
+#define register_shrinker register_shrinker_backport
+#endif
+
 /* <linux/module.h> */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0)
 #define MODULE_IMPORT_NS(ns)

--- a/scst/src/scst_mem.c
+++ b/scst/src/scst_mem.c
@@ -1794,7 +1794,7 @@ int scst_sgv_pools_init(unsigned long mem_hwmark, unsigned long mem_lwmark)
 	sgv_shrinker.shrink = sgv_shrink;
 #endif
 	sgv_shrinker.seeks = DEFAULT_SEEKS;
-	register_shrinker(&sgv_shrinker);
+	register_shrinker(&sgv_shrinker, "scst-sgv");
 
 out:
 	TRACE_EXIT_RES(res);


### PR DESCRIPTION
Support for the following mm layer changes in the Linux kernel v6.0:
- e33c267ab70d ("mm: shrinkers: provide shrinkers with names")