### PR TITLE
iscsi-scst: Fix a typo in SCSTTarget RA

### DIFF
--- a/iscsi-scst/resource_agents/SCSTTarget
+++ b/iscsi-scst/resource_agents/SCSTTarget
@@ -122,7 +122,7 @@ dependent. Neither the name nor the value may contain whitespace.
 <actions>
 <action name="start"        timeout="10" />
 <action name="stop"         timeout="180" />
-<action name="status "      timeout="10" interval="10" depth="0" />
+<action name="status"       timeout="10" interval="10" depth="0" />
 <action name="monitor"      timeout="10" interval="10" depth="0" />
 <action name="meta-data"    timeout="5" />
 <action name="validate-all"   timeout="10" />


### PR DESCRIPTION
Extraneous space in "status" breaks resource monitoring:

    <action name="status " timeout="10" interval="10" depth="0" />

Fixes: https://github.com/SCST-project/scst/issues/80