### PR TITLE
scst/include/backport.h: Fix the register_shrinker() backport

### DIFF
--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -783,7 +783,15 @@ static inline void kvfree(void *addr)
 static inline
 int register_shrinker_backport(struct shrinker *shrinker, const char *fmt, ...)
 {
+/*
+ * See also commit 1d3d4437eae1 ("vmscan: per-node deferred work") # v3.12
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 12, 0)
 	return register_shrinker(shrinker);
+#else
+	register_shrinker(shrinker);
+	return 0;
+#endif
 }
 
 #define register_shrinker register_shrinker_backport

--- a/scst/src/scst_mem.c
+++ b/scst/src/scst_mem.c
@@ -1519,6 +1519,9 @@ static void sgv_pool_destroy(struct sgv_pool *pool)
 
 	TRACE_ENTRY();
 
+	if (unlikely(!pool))
+		goto out;
+
 	sgv_pool_flush(pool);
 
 	mutex_lock(&sgv_pools_mutex);
@@ -1540,6 +1543,7 @@ static void sgv_pool_destroy(struct sgv_pool *pool)
 
 	kmem_cache_free(sgv_pool_cachep, pool);
 
+out:
 	TRACE_EXIT();
 	return;
 }
@@ -1802,18 +1806,15 @@ out:
 
 out_free_per_cpu_dma:
 	for (i = 0; i < nr_cpu_ids; i++)
-		if (sgv_dma_pool_per_cpu[i] != NULL)
-			sgv_pool_destroy(sgv_dma_pool_per_cpu[i]);
+		sgv_pool_destroy(sgv_dma_pool_per_cpu[i]);
 
 out_free_per_cpu_clust:
 	for (i = 0; i < nr_cpu_ids; i++)
-		if (sgv_norm_clust_pool_per_cpu[i] != NULL)
-			sgv_pool_destroy(sgv_norm_clust_pool_per_cpu[i]);
+		sgv_pool_destroy(sgv_norm_clust_pool_per_cpu[i]);
 
 out_free_per_cpu_norm:
 	for (i = 0; i < nr_cpu_ids; i++)
-		if (sgv_norm_pool_per_cpu[i] != NULL)
-			sgv_pool_destroy(sgv_norm_pool_per_cpu[i]);
+		sgv_pool_destroy(sgv_norm_pool_per_cpu[i]);
 
 	sgv_pool_destroy(sgv_dma_pool_main);
 
@@ -1841,18 +1842,15 @@ void scst_sgv_pools_deinit(void)
 
 	sgv_pool_destroy(sgv_dma_pool_main);
 	for (i = 0; i < nr_cpu_ids; i++)
-		if (sgv_dma_pool_per_cpu[i] != NULL)
-			sgv_pool_destroy(sgv_dma_pool_per_cpu[i]);
+		sgv_pool_destroy(sgv_dma_pool_per_cpu[i]);
 
 	sgv_pool_destroy(sgv_norm_pool_main);
 	for (i = 0; i < nr_cpu_ids; i++)
-		if (sgv_norm_pool_per_cpu[i] != NULL)
-			sgv_pool_destroy(sgv_norm_pool_per_cpu[i]);
+		sgv_pool_destroy(sgv_norm_pool_per_cpu[i]);
 
 	sgv_pool_destroy(sgv_norm_clust_pool_main);
 	for (i = 0; i < nr_cpu_ids; i++)
-		if (sgv_norm_clust_pool_per_cpu[i] != NULL)
-			sgv_pool_destroy(sgv_norm_clust_pool_per_cpu[i]);
+		sgv_pool_destroy(sgv_norm_clust_pool_per_cpu[i]);
 
 	for (i = 0; i < nr_cpu_ids; i++)
 		sgv_norm_pool_global[i] = NULL;

--- a/scst/src/scst_mem.c
+++ b/scst/src/scst_mem.c
@@ -1798,7 +1798,10 @@ int scst_sgv_pools_init(unsigned long mem_hwmark, unsigned long mem_lwmark)
 	sgv_shrinker.shrink = sgv_shrink;
 #endif
 	sgv_shrinker.seeks = DEFAULT_SEEKS;
-	register_shrinker(&sgv_shrinker, "scst-sgv");
+
+	res = register_shrinker(&sgv_shrinker, "scst-sgv");
+	if (unlikely(res))
+		goto out_free_per_cpu_dma;
 
 out:
 	TRACE_EXIT_RES(res);
@@ -1828,7 +1831,7 @@ out_free_pool:
 	kmem_cache_destroy(sgv_pool_cachep);
 
 out_err:
-	res = -ENOMEM;
+	res = res ?: -ENOMEM;
 	goto out;
 }
 


### PR DESCRIPTION
The register_shrinker() function has begun return non void value since
v3.12 version. So fix the backport of this function for kernel versions
before v3.12.

Fixes: 84bd33f9a18c ("scst_mem: Port to Linux kernel v6.0")