### PR TITLE
scst/include/backport.h: Fix the build against CentOS 8-stream

### DIFF
--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -1490,6 +1490,9 @@ static inline void scsi_build_sense(struct scsi_cmnd *scmd, int desc,
 #endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
+
+#if (!defined(RHEL_RELEASE_CODE) || \
+	RHEL_RELEASE_CODE -0 != RHEL_RELEASE_VERSION(8, 7))
 /*
  * See also 51f3a4788928 ("scsi: core: Introduce the scsi_cmd_to_rq()
  * function").
@@ -1498,6 +1501,7 @@ static inline struct request *scsi_cmd_to_rq(struct scsi_cmnd *scmd)
 {
 	return scmd->request;
 }
+#endif
 
 /*
  * See also commit c611529e7cd3 ("sd: Honor block layer integrity handling
@@ -1517,7 +1521,9 @@ static inline unsigned int scsi_prot_interval(struct scsi_cmnd *scmd)
  * helper") and ddd0bc756983 ("block: move ref_tag calculation func to the
  * block layer"; v4.19).
  */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0) || defined(RHEL_MAJOR)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0) || \
+	(defined(RHEL_RELEASE_CODE) && \
+	 RHEL_RELEASE_CODE -0 != RHEL_RELEASE_VERSION(8, 7)))
 static inline u32 scsi_prot_ref_tag(struct scsi_cmnd *scmd)
 {
 #if defined(RHEL_MAJOR) && RHEL_MAJOR -0 == 7


### PR DESCRIPTION
Fixes: https://github.com/SCST-project/scst/issues/77