### PR TITLE
scst_lib: Handle an INQUIRY with buffer size 0

### DIFF
--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -1337,38 +1337,6 @@ iov_iter_kvec_backport(struct iov_iter *i, unsigned int direction,
 
 /* <linux/unaligned.h> */
 
-#if defined(RHEL_MAJOR) && RHEL_MAJOR -0 <= 5
-static inline uint16_t get_unaligned_be16(const void *p)
-{
-	return be16_to_cpu(get_unaligned((__be16 *)p));
-}
-
-static inline void put_unaligned_be16(uint16_t i, void *p)
-{
-	put_unaligned(cpu_to_be16(i), (__be16 *)p);
-}
-
-static inline uint32_t get_unaligned_be32(const void *p)
-{
-	return be32_to_cpu(get_unaligned((__be32 *)p));
-}
-
-static inline void put_unaligned_be32(uint32_t i, void *p)
-{
-	put_unaligned(cpu_to_be32(i), (__be32 *)p);
-}
-
-static inline uint64_t get_unaligned_be64(const void *p)
-{
-	return be64_to_cpu(get_unaligned((__be64 *)p));
-}
-
-static inline void put_unaligned_be64(uint64_t i, void *p)
-{
-	put_unaligned(cpu_to_be64(i), (__be64 *)p);
-}
-#endif
-
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 7, 0) && \
 	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 < 8 ||	\
 	 RHEL_MAJOR -0 == 8 && RHEL_MINOR -0 < 4)

--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -1776,9 +1776,9 @@ EXPORT_SYMBOL(scst_set_cmd_error_status);
 static int scst_set_lun_not_supported_request_sense(struct scst_cmd *cmd,
 	int key, int asc, int ascq)
 {
-	int res;
 	int sense_len, len;
 	struct scatterlist *sg;
+	int res = 0;
 
 	TRACE_ENTRY();
 
@@ -1796,6 +1796,12 @@ static int scst_set_lun_not_supported_request_sense(struct scst_cmd *cmd,
 	}
 
 	if (cmd->sg == NULL) {
+		if (cmd->bufflen == 0) {
+			int bufflen = cmd->cdb[4];
+
+			cmd->bufflen = bufflen ?: 18;
+		}
+
 		/*
 		 * If target driver preparing data buffer using tgt_alloc_data_buf()
 		 * callback, it is responsible to copy the sense to its buffer
@@ -1807,9 +1813,6 @@ static int scst_set_lun_not_supported_request_sense(struct scst_cmd *cmd,
 			TRACE_MEM("Tgt sg used for sense for cmd %p", cmd);
 			goto go;
 		}
-
-		if (cmd->bufflen == 0)
-			cmd->bufflen = cmd->cdb[4];
 
 		cmd->sg = scst_alloc_sg(cmd->bufflen, GFP_ATOMIC, &cmd->sg_cnt);
 		if (cmd->sg == NULL) {
@@ -1837,12 +1840,12 @@ go:
 	cmd->data_direction = SCST_DATA_READ;
 	scst_set_resp_data_len(cmd, sense_len);
 
-	res = 0;
 	cmd->completed = 1;
 	cmd->resid_possible = 1;
 
 out:
 	TRACE_EXIT_RES(res);
+
 	return res;
 }
 

--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -1783,8 +1783,8 @@ static int scst_set_lun_not_supported_request_sense(struct scst_cmd *cmd,
 	TRACE_ENTRY();
 
 	if (cmd->status != 0) {
-		TRACE_MGMT_DBG("cmd %p already has status %x set", cmd,
-			cmd->status);
+		TRACE_MGMT_DBG("cmd %p already has status %x set",
+			       cmd, cmd->status);
 		res = -EEXIST;
 		goto out;
 	}
@@ -1813,14 +1813,14 @@ static int scst_set_lun_not_supported_request_sense(struct scst_cmd *cmd,
 
 		cmd->sg = scst_alloc_sg(cmd->bufflen, GFP_ATOMIC, &cmd->sg_cnt);
 		if (cmd->sg == NULL) {
-			PRINT_ERROR("Unable to alloc sg for REQUEST SENSE"
-				"(sense %x/%x/%x)", key, asc, ascq);
+			PRINT_ERROR("Unable to alloc sg for REQUEST SENSE (sense %x/%x/%x)",
+				    key, asc, ascq);
 			res = 1;
 			goto out;
 		}
 
-		TRACE_MEM("sg %p alloced for sense for cmd %p (cnt %d, "
-			"len %d)", cmd->sg, cmd, cmd->sg_cnt, cmd->bufflen);
+		TRACE_MEM("sg %p (cnt %d, len %d) alloced for sense: cmd %p",
+			  cmd->sg, cmd->sg_cnt, cmd->bufflen, cmd);
 	}
 
 go:
@@ -1856,8 +1856,8 @@ static int scst_set_lun_not_supported_inquiry(struct scst_cmd *cmd)
 	TRACE_ENTRY();
 
 	if (cmd->status != 0) {
-		TRACE_MGMT_DBG("cmd %p already has status %x set", cmd,
-			cmd->status);
+		TRACE_MGMT_DBG("cmd %p already has status %x set",
+			       cmd, cmd->status);
 		res = -EEXIST;
 		goto out;
 	}
@@ -1874,22 +1874,20 @@ static int scst_set_lun_not_supported_inquiry(struct scst_cmd *cmd)
 		if (cmd->tgt_i_data_buf_alloced && (cmd->tgt_i_sg != NULL)) {
 			cmd->sg = cmd->tgt_i_sg;
 			cmd->sg_cnt = cmd->tgt_i_sg_cnt;
-			TRACE_MEM("Tgt used for INQUIRY for not supported "
-				"LUN for cmd %p", cmd);
+			TRACE_MEM("Tgt used for INQUIRY (not supported LUN): cmd %p",
+				  cmd);
 			goto go;
 		}
 
 		cmd->sg = scst_alloc_sg(cmd->bufflen, GFP_ATOMIC, &cmd->sg_cnt);
 		if (cmd->sg == NULL) {
-			PRINT_ERROR("%s", "Unable to alloc sg for INQUIRY "
-				"for not supported LUN");
+			PRINT_ERROR("Unable to alloc sg for INQUIRY (not supported LUN)");
 			res = 1;
 			goto out;
 		}
 
-		TRACE_MEM("sg %p alloced for INQUIRY for not supported LUN for "
-			"cmd %p (cnt %d, len %d)", cmd->sg, cmd, cmd->sg_cnt,
-			cmd->bufflen);
+		TRACE_MEM("sg %p (cnt %d, len %d) allocated for INQUIRY (not supported LUN): cmd %p",
+			  cmd->sg, cmd->sg_cnt, cmd->bufflen, cmd);
 	}
 
 go:

--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -1848,10 +1848,10 @@ out:
 
 static int scst_set_lun_not_supported_inquiry(struct scst_cmd *cmd)
 {
-	int res;
 	uint8_t *buf;
 	struct scatterlist *sg;
 	int len;
+	int res = 0;
 
 	TRACE_ENTRY();
 
@@ -1863,8 +1863,11 @@ static int scst_set_lun_not_supported_inquiry(struct scst_cmd *cmd)
 	}
 
 	if (cmd->sg == NULL) {
-		if (cmd->bufflen == 0)
-			cmd->bufflen = min_t(int, 36, get_unaligned_be16(&cmd->cdb[3]));
+		if (cmd->bufflen == 0) {
+			int bufflen = get_unaligned_be16(&cmd->cdb[3]);
+
+			cmd->bufflen = bufflen ? min_t(int, 36, bufflen) : 36;
+		}
 
 		/*
 		 * If target driver preparing data buffer using tgt_alloc_data_buf()
@@ -1909,12 +1912,12 @@ go:
 	cmd->data_direction = SCST_DATA_READ;
 	scst_set_resp_data_len(cmd, len);
 
-	res = 0;
 	cmd->completed = 1;
 	cmd->resid_possible = 1;
 
 out:
 	TRACE_EXIT_RES(res);
+
 	return res;
 }
 


### PR DESCRIPTION
Sending an INQUIRY with a buffer size 0 to the LUN that does not exist
causes the following kernel panic:

RIP: 0010:sg_init_table+0x1e/0x30
Call Trace:
  scst_alloc_sg+0xc3/0x270 [scst]
  scst_set_cmd_error+0x8c9/0xa80 [scst]
  __scst_init_cmd+0x5c3/0xb80 [scst]
  scst_cmd_init_done+0x142/0xae0 [scst]
  cmnd_rx_start+0x7f5/0x13d0 [iscsi_scst]
  isert_pdu_rx+0x54/0x140 [isert_scst]
  isert_recv_completion_handler+0x498/0x580 [isert_scst]
  isert_poll_cq+0x396/0x800 [isert_scst]
  isert_cq_comp_work_cb+0x4a/0x120 [isert_scst]
  process_one_work+0x1d1/0x410 
  worker_thread+0x2b/0x3d0
  kthread+0x11a/0x130
  ret_from_fork+0x1f/0x40

Hence add extra check to avoid the crash.

Reported-by: Lev Vainblat <lev@zadarastorage.com>
