### PR TITLE
scst_targ: Use 'atomic_inc_return' to check 'dev->dev_cmd_count'

### DIFF
--- a/scst/src/scst_targ.c
+++ b/scst/src/scst_targ.c
@@ -4345,8 +4345,7 @@ static int __scst_init_cmd(struct scst_cmd *cmd)
 		}
 
 #ifdef CONFIG_SCST_PER_DEVICE_CMD_COUNT_LIMIT
-		atomic_inc(&dev->dev_cmd_count);
-		cnt = atomic_read(&dev->dev_cmd_count);
+		cnt = atomic_inc_return(&dev->dev_cmd_count);
 		if (unlikely(cnt > SCST_MAX_DEV_COMMANDS)) {
 			if (!failure) {
 				TRACE(TRACE_FLOW_CONTROL,

--- a/scst/src/scst_targ.c
+++ b/scst/src/scst_targ.c
@@ -4334,7 +4334,7 @@ static int __scst_init_cmd(struct scst_cmd *cmd)
 
 		scst_set_cmd_state(cmd, SCST_CMD_STATE_PARSE);
 
-		cnt = atomic_read(&tgt_dev->tgt_dev_cmd_count) - 1;
+		cnt = atomic_read(&tgt_dev->tgt_dev_cmd_count);
 		if (unlikely(cnt > dev->max_tgt_dev_commands)) {
 			TRACE(TRACE_FLOW_CONTROL,
 				"Too many pending commands (%d) in "


### PR DESCRIPTION
1. atomic_inc_return() avoids a race in between atomic_read() & atomic_inc().
2. atomic_inc_return() is a few cycles faster than atomic_inc()/atomic_read() sequence.