### PR TITLE
scst: Drop support for detect() method

### DIFF
--- a/doc/scst_pg.sgml
+++ b/doc/scst_pg.sgml
@@ -163,11 +163,10 @@ struct scst_tgt_template
 
 	int threads_num;
 
-	int (*detect) (struct scst_tgt_template *tgt_template);
 	int (*release)(struct scst_tgt *tgt);
 
 	int (*xmit_response)(struct scst_cmd *cmd);
-	int (* rdy_to_xfer)(struct scst_cmd *cmd);
+	int (*rdy_to_xfer)(struct scst_cmd *cmd);
 
 	void (*on_hw_pending_cmd_timeout) (struct scst_cmd *cmd);
 
@@ -229,13 +228,6 @@ max_hw_pending_time <= t < 2*max_hw_pending_time.
 dedicated threads. Used if xmit_response() or rdy_to_xfer() is blocking.
 It is the target driver's duty to ensure that not more, than that number
 of threads, are blocked in those functions at any time.
-
-<item><bf/int (*detect) (struct scst_tgt_template *tgt_template)/ - this
-function is intended to detect the target adapters that are present in
-the system. Each found adapter should be registered by calling
-<it/scst_register_target()/. The function should return a value >= 0 to
-signify the number of detected target adapters. A negative value should
-be returned whenever there is an error. Must be defined.
 
 <item><bf/int (*release)(struct scst_tgt *tgt)/ - this function is
 intended to free up resources allocated to the device. The function

--- a/scst/include/scst.h
+++ b/scst/include/scst.h
@@ -1006,17 +1006,6 @@ struct scst_tgt_template {
 	void (*on_abort_cmd)(struct scst_cmd *cmd);
 
 	/*
-	 * This function should detect the target adapters that
-	 * are present in the system. The function should return a value
-	 * >= 0 to signify the number of detected target adapters.
-	 * A negative value should be returned whenever there is
-	 * an error.
-	 *
-	 * OBSOLETE
-	 */
-	int (*detect)(struct scst_tgt_template *tgt_template);
-
-	/*
 	 * This function should free up the resources allocated to the device.
 	 * The function should return 0 to indicate successful release
 	 * or a negative value if there are some issues with the release.

--- a/scst/src/scst_main.c
+++ b/scst/src/scst_main.c
@@ -221,10 +221,6 @@ int __scst_register_target_template(struct scst_tgt_template *vtt,
 		goto out;
 	}
 
-	if (vtt->detect)
-		PRINT_WARNING("detect() method is obsolete and scheduled for "
-			"removal (target driver %s)", vtt->name);
-
 	if (!vtt->release) {
 		PRINT_ERROR("Target driver %s must have "
 			"release() method.", vtt->name);
@@ -292,29 +288,11 @@ int __scst_register_target_template(struct scst_tgt_template *vtt,
 	mutex_unlock(&scst_mutex2);
 	mutex_unlock(&scst_mutex);
 
-	TRACE_DBG("%s", "Calling target driver's detect()");
-	res = vtt->detect ? vtt->detect(vtt) : 0;
-	TRACE_DBG("Target driver's detect() returned %d", res);
-	if (res < 0) {
-		PRINT_ERROR("%s", "The detect() routine failed");
-		res = -EINVAL;
-		goto out_del;
-	}
-
 	PRINT_INFO("Target template %s registered successfully", vtt->name);
 
 out:
 	TRACE_EXIT_RES(res);
 	return res;
-
-out_del:
-	scst_tgtt_sysfs_del(vtt);
-
-	mutex_lock(&scst_mutex);
-
-	mutex_lock(&scst_mutex2);
-	list_del(&vtt->scst_template_list_entry);
-	mutex_unlock(&scst_mutex2);
 
 out_unlock:
 	mutex_unlock(&scst_mutex);


### PR DESCRIPTION
Support for scst_tgt_template detect() method was declared obsolete in 2015. Remove support for scst_tgt_template detect() method.

See also commit 4ac6d7a26d1f ("[PATCH] scst: Drop detect() method").