### PR TITLE
pass through `DEBUG_MODE_LEVEL` to `dpkg` make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ else
      KDIR=/lib/modules/$(KVER)/build
 endif
 
+DEBUG_MODE_LEVEL ?= 2release
+
 OLD_QLA_INI_DIR=qla2x00t
 OLD_QLA_DIR=$(OLD_QLA_INI_DIR)/qla2x00-target
 
@@ -440,7 +442,8 @@ dpkg: ../scst_$(VERSION).orig.tar.gz
 	  buildopts+=(-j4);						\
 	fi &&								\
 	DEB_CC_SET="$(CC)" DEB_KVER_SET=$(KVER) DEB_KDIR_SET=$(KDIR) DEB_QLA_DIR_SET=$(QLA_DIR) \
-	   DEB_QLA_INI_DIR_SET=$(QLA_INI_DIR) debuild "$${buildopts[@]}" --lintian-opts --profile debian && \
+	   DEB_QLA_INI_DIR_SET=$(QLA_INI_DIR) DEB_DEBUG_MODE_LEVEL=$(DEBUG_MODE_LEVEL) \
+	   debuild "$${buildopts[@]}" --lintian-opts --profile debian && \
 	mkdir -p dpkg &&						\
 	for f in "$${output_files[@]}" ../scst_$(VERSION).orig.tar.[gx]z; do\
 		mv $$f dpkg || true;					\

--- a/debian/rules
+++ b/debian/rules
@@ -20,6 +20,7 @@ export KDIR=$(DEB_KDIR_SET)
 export CC=$(DEB_CC_SET)
 export QLA_DIR=$(DEB_QLA_DIR_SET)
 export QLA_INI_DIR=$(DEB_QLA_INI_DIR_SET)
+export DEBUG_MODE_LEVEL=$(DEB_DEBUG_MODE_LEVEL)
 
 SUBDIRS=scst $(shell grep -qw '^CONFIG_LIBFC' /boot/config-$(KVER) && echo fcst) iscsi-scst $(QLA_DIR) scst_local scstadmin srpt
 DESTDIR=$(CURDIR)/debian/tmp
@@ -37,7 +38,7 @@ clean:
 
 build:
 	[ -n "$(QLA_INI_DIR)" ] &&					\
-	make 2release &&						\
+	make $(DEBUG_MODE_LEVEL) &&					\
 	export BUILD_2X_MODULE=y &&					\
 	export CONFIG_SCSI_QLA_FC=y &&					\
 	export CONFIG_SCSI_QLA2XXX_TARGET=y &&				\
@@ -70,11 +71,12 @@ install:
 		    break;						\
 	    fi;								\
 	done &&								\
-	make 2debug &&							\
+	make $(DEBUG_MODE_LEVEL) &&					\
 	rm -f "$(DESTDIR)"/lib/modules/*/[Mm]odule* &&			\
 	mkdir -p $(DESTDIR)/usr/src/scst-$(VERSION) &&			\
 	for f in scst.dkms scst-dkms.postinst scst-dkms.prerm; do	\
-		sed "s/\$${PACKAGE_VERSION}/$(VERSION)/"		\
+		sed "s/\$${PACKAGE_VERSION}/$(VERSION)/;		\
+		     s/\$${DEBUG_MODE_LEVEL}/$(DEBUG_MODE_LEVEL)/"	\
 			< debian/$$f.in >debian/$$f || exit $?;	 	\
 	done &&								\
 	cp debian/scst.dkms						\

--- a/debian/scst.dkms.in
+++ b/debian/scst.dkms.in
@@ -1,7 +1,7 @@
 PACKAGE_VERSION="${PACKAGE_VERSION}"
 PACKAGE_NAME="scst"
 AUTOINSTALL=yes
-MAKE[0]="export KVER=${kernelver} KDIR=${kernel_source_dir} BUILD_2X_MODULE=y CONFIG_SCSI_QLA_FC=y CONFIG_SCSI_QLA2XXX_TARGET=y && make 2release && make -sC scst && make -sC fcst && make -sC iscsi-scst && make -sC qla2x00t-32gbit/qla2x00-target && make -sC scst_local && make -sC srpt"
+MAKE[0]="export KVER=${kernelver} KDIR=${kernel_source_dir} BUILD_2X_MODULE=y CONFIG_SCSI_QLA_FC=y CONFIG_SCSI_QLA2XXX_TARGET=y && make ${DEBUG_MODE_LEVEL} && make -sC scst && make -sC fcst && make -sC iscsi-scst && make -sC qla2x00t-32gbit/qla2x00-target && make -sC scst_local && make -sC srpt"
 CLEAN="make clean"
 # Remove any existing ib_srpt.ko kernel modules
 PRE_INSTALL="find /lib/modules/${kernelver} -name ib_srpt.ko -exec rm {} \;"


### PR DESCRIPTION
It's quite strange but we can't run `make dpkg` with other debug mode level. Fix that.