### PR TITLE
scst/include/backport.h: Do not set rq->end_io to NULL

### DIFF
--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -204,15 +204,15 @@ void blk_execute_rq_nowait_backport(struct request *rq, bool at_head)
 	 * See also commit 8eeed0b554b9 ("block: remove unnecessary argument from
 	 * blk_execute_rq_nowait") # v5.12.
 	 */
-	blk_execute_rq_nowait(rq->q, NULL, rq, at_head, NULL);
+	blk_execute_rq_nowait(rq->q, NULL, rq, at_head, rq->end_io);
 #elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
 	/*
 	 * See also commit b84ba30b6c7a ("block: remove the gendisk argument to
 	 * blk_execute_rq") # v5.17.
 	 */
-	blk_execute_rq_nowait(NULL, rq, at_head, NULL);
+	blk_execute_rq_nowait(NULL, rq, at_head, rq->end_io);
 #else
-	blk_execute_rq_nowait(rq, at_head, NULL);
+	blk_execute_rq_nowait(rq, at_head, rq->end_io);
 #endif
 }
 


### PR DESCRIPTION
Fix a regression introduced during [scst_lib: Port to Linux kernel v5.19](https://github.com/SCST-project/scst/commit/d989aa91f31fa8893b7ee10685f552b3eea8395d) that breaks `dev_disk` operation.

The kernel function `blk_execute_rq_nowait` will set `rq->end_io` to the `done` parameter, so pass in the existing `rq->end_io` rather than NULL to prevent zeroing it.

