### PR TITLE
github: Update actions/checkout to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         compiler: [gcc, clang]
         arch: [x86_64]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install build-essential
         run: |
           sudo apt-get update

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get version
         id: get_version

--- a/.github/workflows/mail_notification.yml
+++ b/.github/workflows/mail_notification.yml
@@ -16,7 +16,7 @@ jobs:
         commit: ${{github.event.commits}}
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{matrix.commit.id}}
           fetch-depth: 2


### PR DESCRIPTION
This patch should fix the following github warning:

    Node.js 12 actions are deprecated. Please update the following
    actions to use Node.js 16: actions/checkout@v2