### PR TITLE
scst_sysfs: Add support for cluster_name

### DIFF
--- a/scst/src/scst_dlm.c
+++ b/scst/src/scst_dlm.c
@@ -1510,4 +1510,6 @@ const struct scst_cl_ops scst_dlm_cl_ops = {
 	.reserve		= scst_dlm_reserve,
 };
 
+char *scst_dlm_cluster_name;
+
 #endif

--- a/scst/src/scst_priv.h
+++ b/scst/src/scst_priv.h
@@ -176,6 +176,7 @@ extern wait_queue_head_t scst_dev_cmd_waitQ;
 
 extern const struct scst_cl_ops scst_no_dlm_cl_ops;
 extern const struct scst_cl_ops scst_dlm_cl_ops;
+extern char *scst_dlm_cluster_name;
 
 extern unsigned int scst_setup_id;
 
@@ -417,8 +418,8 @@ static inline int scst_dlm_new_lockspace(const char *name, int namelen,
 					 uint32_t flags,
 					 int lvblen)
 {
-	return dlm_new_lockspace(name, NULL, flags, lvblen, NULL, NULL, NULL,
-				 lockspace);
+	return dlm_new_lockspace(name, scst_dlm_cluster_name, flags, lvblen,
+				 NULL, NULL, NULL, lockspace);
 }
 
 int scst_alloc_space(struct scst_cmd *cmd);


### PR DESCRIPTION
When `dlm_new_lockspace` is called with a NULL `cluster_name` the kernel will emit an error message "_dlm cluster name '%s' is being used without an application provided cluster name_" on each call.

Therefore, provide a mechanism to set a `cluster_name` and use it when calling `dlm_new_lockspace`.

Since dlm will only have one cluster active on a particular host, make this new scst parameter global.