### PR TITLE
scst/include/backport.h: fix iscsi_scst build probem on rhel7.4

### DIFF
--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -577,7 +577,7 @@ static inline long get_user_pages_backport(unsigned long start,
 /* <linux/kobject_ns.h> */
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0) && 	\
-	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 < 7)
+	(!defined(RHEL_MAJOR) || RHEL_MAJOR -0 < 8)
 /*
  * See also commit 5f256becd868 ("[NET]: Basic network namespace
  * infrastructure."; v2.6.24). a685e08987d1 ("Delay struct net freeing while


### PR DESCRIPTION
rhel7.4  kernel: 3.10.0-693.el7.x86_64 , do not have kobj_ns_grab_current  & kobj_ns_drop defined
building process without error, but when insert to kernel failed:
[  457.326962] iscsi_scst: Unknown symbol kobj_ns_grab_current (err 0)
[  457.326971] iscsi_scst: Unknown symbol kobj_ns_drop (err 0)
####
so trying to change RHEL_MAJOR -0 <8 ,
rebuid->modprobe,works fine.