### PR TITLE
scst_vdisk, scstadmin: Allow t10_dev_id to be stored before cluster_mode

### DIFF
--- a/scst/src/dev_handlers/scst_vdisk.c
+++ b/scst/src/dev_handlers/scst_vdisk.c
@@ -6988,6 +6988,33 @@ static int vdev_parse_add_dev_params(struct scst_vdisk_dev *virt_dev,
 			continue;
 		}
 
+		if (!strcasecmp("t10_dev_id", p)) {
+			/* Handle in a fashion similar to vdev_sysfs_t10_dev_id_store */
+			int i, length = strlen(pp);
+
+			if (length >= sizeof(virt_dev->t10_dev_id)) {
+				PRINT_ERROR("T10 device id is too long (max %zd "
+					"characters)", sizeof(virt_dev->t10_dev_id)-1);
+				res = -EINVAL;
+				goto out;
+			}
+
+			memset(virt_dev->t10_dev_id, 0, sizeof(virt_dev->t10_dev_id));
+			memcpy(virt_dev->t10_dev_id, pp, length);
+
+			i = 0;
+			while (i < sizeof(virt_dev->t10_dev_id)) {
+				if (virt_dev->t10_dev_id[i] == '\n') {
+					virt_dev->t10_dev_id[i] = '\0';
+					break;
+				}
+				i++;
+			}
+
+			virt_dev->t10_dev_id_set = 1;
+			continue;
+		}
+
 		res = kstrtoll(pp, 0, &ll_val);
 		if (res != 0) {
 			PRINT_ERROR("strtoll() for %s failed: %d (device %s)",
@@ -9558,6 +9585,7 @@ static const char *const fileio_add_dev_params[] = {
 	"rotational",
 	"thin_provisioned",
 	"tst",
+	"t10_dev_id",
 	"write_through",
 	NULL
 };
@@ -9648,6 +9676,7 @@ static const char *const blockio_add_dev_params[] = {
 	"rotational",
 	"thin_provisioned",
 	"tst",
+	"t10_dev_id",
 	"write_through",
 	NULL
 };
@@ -9721,6 +9750,7 @@ static const char *const nullio_add_dev_params[] = {
 	"size",
 	"size_mb",
 	"tst",
+	"t10_dev_id",
 	NULL
 };
 

--- a/scstadmin/scstadmin.sysfs/scst-1.0.0/lib/SCST/SCST.pm
+++ b/scstadmin/scstadmin.sysfs/scst-1.0.0/lib/SCST/SCST.pm
@@ -3911,10 +3911,17 @@ sub openDevice {
 	    if (!valid($handler, $device, $attributes));
 
 	my $o_string = "";
+	## Special case cluster_mode as we want to set it after t10_dev_id
+	my $cm_string = "";
 	foreach my $attribute (keys %{$attributes}) {
 		my $value = $$attributes{$attribute};
-		$o_string .= "$attribute=$value;";
+		if ($attribute eq "cluster_mode") {
+			$cm_string = "$attribute=$value;";
+		} else {
+			$o_string .= "$attribute=$value;";
+		}
 	}
+	$o_string .= $cm_string;
 
 	$o_string =~ s/\s$//;
 


### PR DESCRIPTION
Since `cluster_mode` relies upon the `t10_dev_id` to generate a namespace, once `cluster_mode` is set the `t10_dev_id` can no longer be changed.  This reasonable restriction is enforced by `scst_dev_sysfs_pr_file_name_store`.

However, because `cluster_mode` is listed as one of the various _add_dev_params_, this meant that it would be set earlier than `t10_dev_id` when `scstadmin` processes _scst.conf_.  The upshot is that having `cluster_mode 1` in _scst.conf_ means that the `t10_dev_id` is ignored.

Rectify by adding `t10_dev_id` to `fileio_add_dev_params`, etc and modifying the _SCST.pm_ `openDevice `so that `cluster_mode` is set last.