### PR TITLE
scst_lib,scst_sysfs: Add aen_disabled setting

### DIFF
--- a/scst/README
+++ b/scst/README
@@ -825,6 +825,13 @@ Every target should have at least the following entries:
 
    For instance, read_unaligned_cmd_count means number of 4K unaligned IOs.
 
+ - aen_disabled - if set this target port is not to send AEN (Asynchronous
+   Event Notification), but rather generate a Unit Attention - even if the
+   underlying transport does support AEN.
+
+   This could prove useful in different situations including when the target
+   is also a forward_dst.
+
 A target driver may have also the following entries:
 
  - "hw_target" - if the target driver supports both hardware and virtual

--- a/scst/include/scst.h
+++ b/scst/include/scst.h
@@ -481,6 +481,9 @@ enum scst_exec_res {
 /* Cache of tgt->tgt_forward_dst */
 #define SCST_TGT_DEV_FORWARD_DST	5
 
+/* Cache of tgt->tgt_aen_disabled */
+#define SCST_TGT_DEV_AEN_DISABLED	6
+
 /*************************************************************
  ** I/O grouping types. Changing them don't forget to change
  ** the corresponding *_STR values in scst_const.h!
@@ -1693,6 +1696,12 @@ struct scst_tgt {
 	 * supposed to be checked at the side of the forwarding source.
 	 */
 	unsigned tgt_forward_dst:1;
+
+	/*
+	 * Set if do not to wish to send AEN from this target port, even if
+	 * supported by the transport.  Send a UA instead.
+	 */
+	unsigned int tgt_aen_disabled:1;
 
 	/* Per target analog of the corresponding driver's fields */
 	unsigned tgt_dif_supported:1;

--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -2511,6 +2511,15 @@ void scst_gen_aen_or_ua(struct scst_tgt_dev *tgt_dev,
 	    sess->shut_phase != SCST_SESS_SPH_READY)
 		goto out;
 
+	if (unlikely(test_bit(SCST_TGT_DEV_AEN_DISABLED,
+			      &tgt_dev->tgt_dev_flags))) {
+		/*
+		 * We have decided not to generate an AEN
+		 * even if supported by the transport.
+		 */
+		goto queue_ua;
+	}
+
 	if (tgtt->report_aen != NULL) {
 		struct scst_aen *aen;
 		int rc;
@@ -5300,6 +5309,10 @@ static int scst_alloc_add_tgt_dev(struct scst_session *sess,
 		set_bit(SCST_TGT_DEV_FORWARD_DST, &tgt_dev->tgt_dev_flags);
 	else
 		clear_bit(SCST_TGT_DEV_FORWARD_DST, &tgt_dev->tgt_dev_flags);
+	if (sess->tgt->tgt_aen_disabled)
+		set_bit(SCST_TGT_DEV_AEN_DISABLED, &tgt_dev->tgt_dev_flags);
+	else
+		clear_bit(SCST_TGT_DEV_AEN_DISABLED, &tgt_dev->tgt_dev_flags);
 	tgt_dev->hw_dif_same_sg_layout_required = sess->tgt->tgt_hw_dif_same_sg_layout_required;
 	tgt_dev->tgt_dev_dif_guard_format = acg_dev->acg_dev_dif_guard_format;
 	if (tgt_dev->tgt_dev_dif_guard_format == SCST_DIF_GUARD_FORMAT_IP)


### PR DESCRIPTION
Add a setting to `scst_tgt` that can prevent `scst_gen_aen_or_ua` from generating an AEN, even if the underlying transport is capable of transmitting them.  It will instead generate a UA.

This could prove useful in different situations, including when the target port is also a _forward_dst_.

(The new _sysfs_ interface was modeled on the code for _forward_dst_.)