### PR TITLE
scst/include/backport.h: Fix building on RHEL 8.8

### DIFF
--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -1474,7 +1474,7 @@ static inline void scsi_build_sense(struct scsi_cmnd *scmd, int desc,
 	 RHEL_RELEASE_CODE -0 < RHEL_RELEASE_VERSION(9, 1))
 
 #if (!defined(RHEL_RELEASE_CODE) || \
-	RHEL_RELEASE_CODE -0 != RHEL_RELEASE_VERSION(8, 7))
+	RHEL_RELEASE_CODE -0 < RHEL_RELEASE_VERSION(8, 7))
 /*
  * See also 51f3a4788928 ("scsi: core: Introduce the scsi_cmd_to_rq()
  * function").
@@ -1505,7 +1505,7 @@ static inline unsigned int scsi_prot_interval(struct scsi_cmnd *scmd)
  */
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0) || \
 	(defined(RHEL_RELEASE_CODE) && \
-	 RHEL_RELEASE_CODE -0 != RHEL_RELEASE_VERSION(8, 7)))
+	 RHEL_RELEASE_CODE -0 < RHEL_RELEASE_VERSION(8, 7)))
 static inline u32 scsi_prot_ref_tag(struct scsi_cmnd *scmd)
 {
 #if defined(RHEL_MAJOR) && RHEL_MAJOR -0 == 7


### PR DESCRIPTION
As in #77, SCST fails to install on RHEL 8.8 due to duplicate symbols:

```
[scst-3.7]# make 2release
cd scst && make 2release
make[1]: Entering directory '/root/scst-3.7/scst'
make[1]: Leaving directory '/root/scst-3.7/scst'
[scst-3.7]# make install
if [ install = extraclean ]; then rm -f TAGS tags cscope.out; fi
for d in scst iscsi-scst qla2x00t-32gbit/qla2x00-target srpt        \
        scst_local fcst usr scstadmin; do \
        make -j$(nproc) -C "$d" install || break;                   \
done
make[1]: Entering directory '/root/scst-3.7/scst'
cd src && make install
make[2]: Entering directory '/root/scst-3.7/scst/src'
make -C certs KDIR=/lib/modules/4.18.0-477.el8.x86_64/build                                     \

make[3]: Entering directory '/root/scst-3.7/scst/src/certs'
openssl req -new -nodes -utf8 -sha256 -days 365000 \
        -batch -x509 -config x509.genkey -outform DER -out scst_module_key.der \
        -keyout scst_module_key.priv
openssl req -new -nodes -utf8 -sha256 -days 365000 \
        -batch -x509 -config x509.genkey -outform DER -out scst_module_key.der \
        -keyout scst_module_key.priv
Generating a RSA private key
Generating a RSA private key
..........................................................................+.++.+
..+.+.++
..............................................+.++.+
writing new private key to 'scst_module_key.priv'
-----
..chmod 600 scst_module_key.der
.....++++
writing new private key to 'scst_module_key.priv'
-----
chmod 600 scst_module_key.priv
make[3]: Leaving directory '/root/scst-3.7/scst/src/certs'
make -C /lib/modules/4.18.0-477.el8.x86_64/build M=/root/scst-3.7/scst/src                              \

make[3]: Entering directory '/usr/src/kernels/4.18.0-477.el8.x86_64'
  CC [M]  /root/scst-3.7/scst/src/scst_copy_mgr.o
  CC [M]  /root/scst-3.7/scst/src/scst_debug.o
  CC [M]  /root/scst-3.7/scst/src/scst_dlm.o
  CC [M]  /root/scst-3.7/scst/src/scst_event.o
In file included from /root/scst-3.7/scst/src/../include/scst.h:64,
                 from /root/scst-3.7/scst/src/scst_debug.c:31:
/root/scst-3.7/scst/src/../include/backport.h:1474:31: error: redefinition of ‘scsi_cmd_to_rq’
 static inline struct request *scsi_cmd_to_rq(struct scsi_cmnd *scmd)
                               ^~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:54,
                 from /root/scst-3.7/scst/src/scst_debug.c:31:
./include/scsi/scsi_cmnd.h:171:31: note: previous definition of ‘scsi_cmd_to_rq’ was here
 static inline struct request *scsi_cmd_to_rq(struct scsi_cmnd *scmd)
                               ^~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:64,
                 from /root/scst-3.7/scst/src/scst_debug.c:31:
/root/scst-3.7/scst/src/../include/backport.h:1501:19: error: redefinition of ‘scsi_prot_ref_tag’
 static inline u32 scsi_prot_ref_tag(struct scsi_cmnd *scmd)
                   ^~~~~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:54,
                 from /root/scst-3.7/scst/src/scst_debug.c:31:
./include/scsi/scsi_cmnd.h:327:19: note: previous definition of ‘scsi_prot_ref_tag’ was here
 static inline u32 scsi_prot_ref_tag(struct scsi_cmnd *scmd)
                   ^~~~~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:64,
                 from /root/scst-3.7/scst/src/scst_copy_mgr.c:17:
/root/scst-3.7/scst/src/../include/backport.h:1474:31: error: redefinition of ‘scsi_cmd_to_rq’
 static inline struct request *scsi_cmd_to_rq(struct scsi_cmnd *scmd)
                               ^~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:54,
                 from /root/scst-3.7/scst/src/scst_copy_mgr.c:17:
./include/scsi/scsi_cmnd.h:171:31: note: previous definition of ‘scsi_cmd_to_rq’ was here
 static inline struct request *scsi_cmd_to_rq(struct scsi_cmnd *scmd)
                               ^~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:64,
                 from /root/scst-3.7/scst/src/scst_copy_mgr.c:17:
/root/scst-3.7/scst/src/../include/backport.h:1501:19: error: redefinition of ‘scsi_prot_ref_tag’
 static inline u32 scsi_prot_ref_tag(struct scsi_cmnd *scmd)
                   ^~~~~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:54,
                 from /root/scst-3.7/scst/src/scst_copy_mgr.c:17:
./include/scsi/scsi_cmnd.h:327:19: note: previous definition of ‘scsi_prot_ref_tag’ was here
 static inline u32 scsi_prot_ref_tag(struct scsi_cmnd *scmd)
                   ^~~~~~~~~~~~~~~~~
make[4]: *** [scripts/Makefile.build:317: /root/scst-3.7/scst/src/scst_debug.o] Error 1
make[4]: *** Waiting for unfinished jobs....
In file included from /root/scst-3.7/scst/src/../include/scst.h:64,
                 from /root/scst-3.7/scst/src/scst_dlm.c:26:
/root/scst-3.7/scst/src/../include/backport.h:1474:31: error: redefinition of ‘scsi_cmd_to_rq’
 static inline struct request *scsi_cmd_to_rq(struct scsi_cmnd *scmd)
                               ^~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:54,
                 from /root/scst-3.7/scst/src/scst_dlm.c:26:
./include/scsi/scsi_cmnd.h:171:31: note: previous definition of ‘scsi_cmd_to_rq’ was here
 static inline struct request *scsi_cmd_to_rq(struct scsi_cmnd *scmd)
                               ^~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:64,
                 from /root/scst-3.7/scst/src/scst_dlm.c:26:
/root/scst-3.7/scst/src/../include/backport.h:1501:19: error: redefinition of ‘scsi_prot_ref_tag’
 static inline u32 scsi_prot_ref_tag(struct scsi_cmnd *scmd)
                   ^~~~~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:54,
                 from /root/scst-3.7/scst/src/scst_dlm.c:26:
./include/scsi/scsi_cmnd.h:327:19: note: previous definition of ‘scsi_prot_ref_tag’ was here
 static inline u32 scsi_prot_ref_tag(struct scsi_cmnd *scmd)
                   ^~~~~~~~~~~~~~~~~
make[4]: *** [scripts/Makefile.build:317: /root/scst-3.7/scst/src/scst_copy_mgr.o] Error 1
make[4]: *** [scripts/Makefile.build:317: /root/scst-3.7/scst/src/scst_dlm.o] Error 1
In file included from /root/scst-3.7/scst/src/../include/scst.h:64,
                 from /root/scst-3.7/scst/src/scst_event.c:26:
/root/scst-3.7/scst/src/../include/backport.h:1474:31: error: redefinition of ‘scsi_cmd_to_rq’
 static inline struct request *scsi_cmd_to_rq(struct scsi_cmnd *scmd)
                               ^~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:54,
                 from /root/scst-3.7/scst/src/scst_event.c:26:
./include/scsi/scsi_cmnd.h:171:31: note: previous definition of ‘scsi_cmd_to_rq’ was here
 static inline struct request *scsi_cmd_to_rq(struct scsi_cmnd *scmd)
                               ^~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:64,
                 from /root/scst-3.7/scst/src/scst_event.c:26:
/root/scst-3.7/scst/src/../include/backport.h:1501:19: error: redefinition of ‘scsi_prot_ref_tag’
 static inline u32 scsi_prot_ref_tag(struct scsi_cmnd *scmd)
                   ^~~~~~~~~~~~~~~~~
In file included from /root/scst-3.7/scst/src/../include/scst.h:54,
                 from /root/scst-3.7/scst/src/scst_event.c:26:
./include/scsi/scsi_cmnd.h:327:19: note: previous definition of ‘scsi_prot_ref_tag’ was here
 static inline u32 scsi_prot_ref_tag(struct scsi_cmnd *scmd)
                   ^~~~~~~~~~~~~~~~~
make[4]: *** [scripts/Makefile.build:317: /root/scst-3.7/scst/src/scst_event.o] Error 1
make[3]: *** [Makefile:1616: _module_/root/scst-3.7/scst/src] Error 2
make[3]: Leaving directory '/usr/src/kernels/4.18.0-477.el8.x86_64'
make[2]: *** [Makefile:75: all] Error 2
make[2]: Leaving directory '/root/scst-3.7/scst/src'
make[1]: *** [Makefile:39: install] Error 2
make[1]: Leaving directory '/root/scst-3.7/scst'
[scst-3.7]#
```

This diff extends the existing check to cover the new version as well. With the fix, things work as expected:

```
[scst-3.7]# make install

    ..<snip make output>..

If you want SCST to start automatically at boot time, run the following command:
systemctl enable scst.service

make[1]: Leaving directory '/root/scst-3.7/scstadmin'
[scst-3.7]# systemctl enable scst.service
scst.service is not a native service, redirecting to systemd-sysv-install.
Executing: /usr/lib/systemd/systemd-sysv-install enable scst
[scst-3.7]# systemctl start scst
[scst-3.7]# systemctl status scst
● scst.service - LSB: SCST - A Generic SCSI Target Subsystem
   Loaded: loaded (/etc/rc.d/init.d/scst; generated)
   Active: active (exited) since Fri 2023-03-31 13:06:44 EDT; 820ms ago
     Docs: man:systemd-sysv-generator(8)
  Process: 98636 ExecStart=/etc/rc.d/init.d/scst start (code=exited, status=0/SUCCESS)

Mar 31 13:06:44 sdot-b200-011c-d3 systemd[1]: Starting LSB: SCST - A Generic SCSI Target Subsystem...
Mar 31 13:06:44 sdot-b200-011c-d3 scst[98636]: Loading and configuring SCSTSCST configuration file /etc/scst.conf missing
Mar 31 13:06:44 sdot-b200-011c-d3 scst[98655]: [  OK  ]
Mar 31 13:06:44 sdot-b200-011c-d3 systemd[1]: Started LSB: SCST - A Generic SCSI Target Subsystem.
[scst-3.7]# lsmod | grep scst
scst                 3624960  0
dlm                   221184  1 scst
[scst-3.7]#
```