### PR TITLE
scst_pres,scst_dlm: Fix broken UNIT ATTENTION for remote PR registrants

### DIFF
--- a/scst/src/scst_dlm.h
+++ b/scst/src/scst_dlm.h
@@ -34,6 +34,7 @@
 #define PR_PRE_UPDATE_LOCK	"pr_pre_%d"
 #define PR_POST_UPDATE_LOCK	"pr_post_%d"
 #define PR_REG_LOCK		"pr_reg_%02d"
+#define PR_REG_UA_LOCK		"pr_reg_%02d_ua_%02d"
 
 /*
  * Data members needed for managing PR data via the DLM.
@@ -142,6 +143,10 @@ struct pr_lvb {
  * @version:	version of this structure
  * @is_holder:	whether or not holding the reservation
  * @tid:	transport ID - up to 228 bytes for iSCSI
+ * @registered_by_nodeid: Corosync node ID of the node holding that
+ *		made the registration.
+ * @next_rem_ua_idx: Index to be used when publishing the next UA
+ * @pad:	Ensure this struct is a multiple of 8 bytes
  */
 struct pr_reg_lvb {
 	__be64	key;
@@ -149,6 +154,22 @@ struct pr_reg_lvb {
 	u8	version;
 	u8	is_holder;
 	u8	tid[228];
+	__be32  registered_by_nodeid;
+	__be16	next_rem_ua_idx;
+	u8	pad[2];
+};
+
+/**
+ * struct dlm_ua_lvb - PR_REG_UA_LOCK LVB data format
+ * @key:	sense key
+ * @asc:	additional sense code
+ * @ascq:	additional sense code qualifier
+ */
+struct dlm_ua_lvb {
+	u8	version;
+	u8	key;
+	u8	asc;
+	u8	ascq;
 };
 
 #endif /* __SCST_PRES_DLM_H */

--- a/scst/src/scst_no_dlm.c
+++ b/scst/src/scst_no_dlm.c
@@ -101,6 +101,12 @@ static void scst_no_dlm_reserve(struct scst_device *dev,
 	dev->reserved_by = sess;
 }
 
+static void scst_no_dlm_pr_reg_queue_rem_ua(struct scst_device *dev,
+					    struct scst_dev_registrant *reg,
+					    int key, int asc, int ascq)
+{
+}
+
 const struct scst_cl_ops scst_no_dlm_cl_ops = {
 	.pr_init		= scst_no_dlm_pr_init,
 	.pr_cleanup		= scst_no_dlm_pr_cleanup,
@@ -115,4 +121,5 @@ const struct scst_cl_ops scst_no_dlm_cl_ops = {
 	.is_rsv_holder		= scst_no_dlm_is_rsv_holder,
 	.is_not_rsv_holder	= scst_no_dlm_is_not_rsv_holder,
 	.reserve		= scst_no_dlm_reserve,
+	.pr_reg_queue_rem_ua	= scst_no_dlm_pr_reg_queue_rem_ua,
 };

--- a/scst/src/scst_pres.c
+++ b/scst/src/scst_pres.c
@@ -539,7 +539,7 @@ static void scst_pr_remove_registrants(struct scst_device *dev)
 }
 
 /* Must be called under dev_pr_mutex */
-static void scst_pr_send_ua_reg(struct scst_device *dev,
+void scst_pr_send_ua_reg(struct scst_device *dev,
 	struct scst_dev_registrant *reg,
 	int key, int asc, int ascq)
 {
@@ -558,6 +558,8 @@ static void scst_pr_send_ua_reg(struct scst_device *dev,
 
 	if (reg->tgt_dev)
 		scst_check_set_UA(reg->tgt_dev, ua, sizeof(ua), 0);
+	else
+		dev->cl_ops->pr_reg_queue_rem_ua(dev, reg, key, asc, ascq);
 
 	TRACE_EXIT();
 	return;

--- a/scst/src/scst_pres.h
+++ b/scst/src/scst_pres.h
@@ -142,6 +142,9 @@ struct scst_dev_registrant *scst_pr_add_registrant(struct scst_device *dev,
 						   bool dev_lock_locked);
 void scst_pr_remove_registrant(struct scst_device *dev,
 			       struct scst_dev_registrant *reg);
+void scst_pr_send_ua_reg(struct scst_device *dev,
+			 struct scst_dev_registrant *reg,
+			 int key, int asc, int ascq);
 void scst_pr_set_holder(struct scst_device *dev,
 			struct scst_dev_registrant *holder, uint8_t scope,
 			uint8_t type);


### PR DESCRIPTION
Previously, when `scst_pr_send_ua_reg` attempted to deliver a UNIT ATTENTION to a registrant that was on another node in a dlm-based HA cluster, the unit attention was dropped.

This breaks, for example, _SPC-5 5.14.12.2.2 Releasing_ 
> if the NUAR bit (see 7.5.11) is set to zero and the released persistent reservation is either a registrants 
> only type or an all registrants type persistent reservation, then the device server shall establish a unit 
> attention condition for the SCSI initiator port associated with every registered I_T nexus other than I_T 
> nexus on which the PERSISTENT RESERVE OUT command with RELEASE service action was 
> received, with the additional sense code set to RESERVATIONS RELEASED

Rectify by adding a `pr_reg_queue_rem_ua` function to `struct scst_cl_ops` and calling it from `scst_pr_send_ua_reg`.

Each registrant will maintain an incoming 'queue' of unit attentions by adding `next_rem_ua_idx` to the registrant data maintained in the DLM.  This will tell the other nodes which `PR_REG_UA_LOCK` lock to create in the lockspace in order to 'send' a unit attention to the registrant.

Further, each node will also maintain two lists (pending and sent) for the outgoing unit attentions from this node to a registrant.  When the recipient has read all the sent unit attentions (and cleared `next_rem_ua_idx`), then the sent list may be cleared.