### PR TITLE
scsi-scstd: Check initiator name provided during login

### DIFF
--- a/iscsi-scst/include/iscsi_scst.h
+++ b/iscsi-scst/include/iscsi_scst.h
@@ -70,6 +70,7 @@ static inline void set_fs(mm_segment_t seg) { }
 #include "iscsi_scst_itf_ver.h"
 
 /* The maximum length of 223 bytes in the RFC. */
+#define ISCSI_NAME_CHECK_LEN	223	/* Checked during LOGIN */
 #define ISCSI_NAME_LEN		256
 
 #define ISCSI_PORTAL_LEN	64


### PR DESCRIPTION
The iSCSI specification has rules wrt what constitutes a valid initiator name.  Perform some checks and reject LOGINs with an invalid initiator name.