### PR TITLE
scst: Unbreak the build for kernel versions <= 6.3

### DIFF
--- a/qla2x00t-32gbit/qla_os.c
+++ b/qla2x00t-32gbit/qla_os.c
@@ -5084,7 +5084,7 @@ struct scsi_qla_host *qla2x00_create_host(const struct scsi_host_template *sht,
 	struct Scsi_Host *host;
 	struct scsi_qla_host *vha = NULL;
 
-	host = scsi_host_alloc(sht, sizeof(scsi_qla_host_t));
+	host = scsi_host_alloc((struct scsi_host_template *) sht, sizeof(scsi_qla_host_t));
 	if (!host) {
 		ql_log_pci(ql_log_fatal, ha->pdev, 0x0107,
 		    "Failed to allocate host from the scsi layer, aborting.\n");

--- a/qla2x00t/qla_os.c
+++ b/qla2x00t/qla_os.c
@@ -3625,7 +3625,7 @@ struct scsi_qla_host *qla2x00_create_host(const struct scsi_host_template *sht,
 	struct Scsi_Host *host;
 	struct scsi_qla_host *vha = NULL;
 
-	host = scsi_host_alloc(sht, sizeof(scsi_qla_host_t));
+	host = scsi_host_alloc((struct scsi_host_template *) sht, sizeof(scsi_qla_host_t));
 	if (host == NULL) {
 		ql_log_pci(ql_log_fatal, ha->pdev, 0x0107,
 		    "Failed to allocate host from the scsi layer, aborting.\n");

--- a/scst_local/scst_local.c
+++ b/scst_local/scst_local.c
@@ -1425,7 +1425,8 @@ static int scst_local_driver_probe(struct device *dev)
 
 	TRACE_DBG("sess %p", sess);
 
-	hpnt = scsi_host_alloc(&scst_lcl_ini_driver_template, sizeof(*sess));
+	hpnt = scsi_host_alloc((struct scsi_host_template *) &scst_lcl_ini_driver_template,
+				sizeof(*sess));
 	if (hpnt == NULL) {
 		PRINT_ERROR("%s", "scsi_register() failed");
 		ret = -ENODEV;


### PR DESCRIPTION
The previous series of patches introduced the use of a const pointer to scsi_host_template. However, scsi_host_alloc() uses a non-const pointer prior to kernel version 6.4, causing the build to throw the following error:

    passing argument 1 of ‘scsi_host_alloc’ discards ‘const’ qualifier
    from pointer target type

Hence, cast away the constness to resolve the error.