### PR TITLE
scst: Remove support for RHEL5/6

### DIFF
--- a/iscsi-scst/kernel/isert-scst/iser.h
+++ b/iscsi-scst/kernel/isert-scst/iser.h
@@ -42,14 +42,6 @@
 #ifndef INSIDE_KERNEL_TREE
 #include <linux/version.h>
 #endif
-
-#if defined(RHEL_MAJOR) && RHEL_MAJOR -0 == 5
-static inline u16 vlan_dev_vlan_id(const void *dev)
-{
-	BUG();
-	return 0;
-}
-#endif
 #include <rdma/rdma_cm.h>
 
 #include "iser_hdr.h"

--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -3118,10 +3118,6 @@ int scst_get_cmd_abnormal_done_state(struct scst_cmd *cmd)
 		PRINT_CRIT_ERROR("Wrong cmd state %d (cmd %p, op %s)",
 			cmd->state, cmd, scst_get_opcode_name(cmd));
 		sBUG();
-#if defined(RHEL_MAJOR) && RHEL_MAJOR -0 < 6
-		/* Invalid state to suppress a compiler warning */
-		res = SCST_CMD_STATE_LAST_ACTIVE;
-#endif
 	}
 
 	if (trace) {

--- a/scst/src/scst_targ.c
+++ b/scst/src/scst_targ.c
@@ -4726,14 +4726,9 @@ void scst_process_active_cmd(struct scst_cmd *cmd, bool atomic)
 			break;
 
 		default:
-			PRINT_CRIT_ERROR("cmd (%p) in state %d, but shouldn't "
-				"be", cmd, cmd->state);
+			PRINT_CRIT_ERROR("cmd (%p) in state %d, but shouldn't be",
+					cmd, cmd->state);
 			sBUG();
-#if defined(RHEL_MAJOR) && RHEL_MAJOR -0 < 6
-			/* For suppressing a gcc compiler warning */
-			res = SCST_CMD_STATE_RES_CONT_NEXT;
-			break;
-#endif
 		}
 	} while (res == SCST_CMD_STATE_RES_CONT_SAME);
 

--- a/srpt/src/ib_srpt.h
+++ b/srpt/src/ib_srpt.h
@@ -48,12 +48,6 @@
 #include <linux/version.h>
 #include <scst.h>
 #endif
-#if defined(RHEL_MAJOR) && RHEL_MAJOR -0 == 5
-#define vlan_dev_vlan_id(dev) (panic("RHEL 5 misses vlan_dev_vlan_id()"), 0)
-#endif
-#if defined(RHEL_MAJOR) && RHEL_MAJOR -0 <= 6
-#define __ethtool_get_settings(dev, cmd) (panic("RHEL misses __ethtool_get_settings()"), 0)
-#endif
 #include <linux/rtnetlink.h>
 #include <rdma/rdma_cm.h>
 #include "ib_dm_mad.h"


### PR DESCRIPTION
The SCST has dropped support for RHEL5/6 since v3.6.