### PR TITLE
scst: Unbreak the non-DLM build

### DIFF
--- a/scst/src/scst_dlm.c
+++ b/scst/src/scst_dlm.c
@@ -1831,6 +1831,4 @@ const struct scst_cl_ops scst_dlm_cl_ops = {
 	.pr_reg_queue_rem_ua	= scst_dlm_pr_reg_queue_rem_ua,
 };
 
-char *scst_dlm_cluster_name;
-
 #endif

--- a/scst/src/scst_main.c
+++ b/scst/src/scst_main.c
@@ -93,6 +93,8 @@ struct kmem_cache *scst_sess_cachep;
 struct kmem_cache *scst_acgd_cachep;
 static struct kmem_cache *scst_thr_cachep;
 
+char *scst_cluster_name;
+
 unsigned int scst_setup_id;
 
 spinlock_t scst_init_lock;
@@ -2599,7 +2601,6 @@ static void __exit exit_scst(void)
 
 	scst_cm_exit();
 
-
 	scst_stop_global_threads();
 
 	scst_deinit_threads(&scst_main_cmd_threads);
@@ -2609,12 +2610,13 @@ static void __exit exit_scst(void)
 
 	scsi_unregister_interface(&scst_interface);
 
-
 	scst_sgv_pools_deinit();
 
 	scst_tg_cleanup();
 
 	scst_sysfs_cleanup();
+
+	kfree(scst_cluster_name);
 
 	scst_event_exit();
 

--- a/scst/src/scst_priv.h
+++ b/scst/src/scst_priv.h
@@ -176,7 +176,7 @@ extern wait_queue_head_t scst_dev_cmd_waitQ;
 
 extern const struct scst_cl_ops scst_no_dlm_cl_ops;
 extern const struct scst_cl_ops scst_dlm_cl_ops;
-extern char *scst_dlm_cluster_name;
+extern char *scst_cluster_name;
 
 extern unsigned int scst_setup_id;
 
@@ -418,7 +418,7 @@ static inline int scst_dlm_new_lockspace(const char *name, int namelen,
 					 uint32_t flags,
 					 int lvblen)
 {
-	return dlm_new_lockspace(name, scst_dlm_cluster_name, flags, lvblen,
+	return dlm_new_lockspace(name, scst_cluster_name, flags, lvblen,
 				 NULL, NULL, NULL, lockspace);
 }
 

--- a/scst/src/scst_sysfs.c
+++ b/scst/src/scst_sysfs.c
@@ -7701,8 +7701,8 @@ static ssize_t scst_cluster_name_show(struct kobject *kobj,
 
 	TRACE_ENTRY();
 
-	if (scst_dlm_cluster_name != NULL)
-		res = sprintf(buf, "%s\n%s", scst_dlm_cluster_name,
+	if (scst_cluster_name != NULL)
+		res = sprintf(buf, "%s\n%s", scst_cluster_name,
 			SCST_SYSFS_KEY_MARK "\n");
 
 	TRACE_EXIT_RES(res);
@@ -7726,8 +7726,8 @@ static ssize_t scst_cluster_name_store(struct kobject *kobj,
 		len--;
 
 	if (len == 0) {
-		kfree(scst_dlm_cluster_name);
-		scst_dlm_cluster_name = NULL;
+		kfree(scst_cluster_name);
+		scst_cluster_name = NULL;
 		goto out_done;
 	}
 
@@ -7737,11 +7737,11 @@ static ssize_t scst_cluster_name_store(struct kobject *kobj,
 		goto out;
 	}
 
-	kfree(scst_dlm_cluster_name);
-	scst_dlm_cluster_name = kstrndup(buf, len, GFP_KERNEL);
-	if (!scst_dlm_cluster_name) {
+	kfree(scst_cluster_name);
+	scst_cluster_name = kstrndup(buf, len, GFP_KERNEL);
+	if (!scst_cluster_name) {
 		PRINT_ERROR("Unable to alloc cluster_name string (len %d)",
-			len+1);
+			    len + 1);
 		res = -ENOMEM;
 		goto out;
 	}
@@ -8097,7 +8097,6 @@ void scst_sysfs_cleanup(void)
 	TRACE_ENTRY();
 
 	PRINT_INFO("%s", "Exiting SCST sysfs hierarchy...");
-	kfree(scst_dlm_cluster_name);
 
 	scst_del_put_sgv_kobj();
 


### PR DESCRIPTION
Fix the following compiler error:

    ERROR: modpost: "scst_dlm_cluster_name" [...] undefined!

The error occurs because the declaration of scst_dlm_cluster_name is located in the scst_dlm.c file, but it's used in the scst_sysfs.c file. As a result, when building without DLM, this variable lacks a declaration.

To resolve this, the declaration is moved to the scst_main.c file, and the variable scst_dlm_cluster_name is renamed to scst_cluster_name.

Fixes: 00f31004ab2b ("scst_sysfs: Add support for cluster_name")