### PR TITLE
scst: Use scst_wait_event_...() with INTERRUPTIBLE sleep

### DIFF
--- a/iscsi-scst/kernel/nthread.c
+++ b/iscsi-scst/kernel/nthread.c
@@ -960,7 +960,7 @@ int istrd(void *arg)
 
 	spin_lock_bh(&p->rd_lock);
 	while (!kthread_should_stop()) {
-		scst_wait_event_lock_bh(p->rd_waitQ, test_rd_list(p), p->rd_lock);
+		scst_wait_event_interruptible_lock_bh(p->rd_waitQ, test_rd_list(p), p->rd_lock);
 		scst_do_job_rd(p);
 	}
 	spin_unlock_bh(&p->rd_lock);
@@ -1612,7 +1612,7 @@ int istwr(void *arg)
 
 	spin_lock_bh(&p->wr_lock);
 	while (!kthread_should_stop()) {
-		scst_wait_event_lock_bh(p->wr_waitQ, test_wr_list(p), p->wr_lock);
+		scst_wait_event_interruptible_lock_bh(p->wr_waitQ, test_wr_list(p), p->wr_lock);
 		scst_do_job_wr(p);
 	}
 	spin_unlock_bh(&p->wr_lock);

--- a/scst/src/dev_handlers/scst_user.c
+++ b/scst/src/dev_handlers/scst_user.c
@@ -2233,9 +2233,9 @@ static int dev_user_get_next_cmd(struct scst_user_dev *dev,
 	TRACE_ENTRY();
 
 	while (1) {
-		scst_wait_event_lock_irq(dev->udev_cmd_threads.cmd_list_waitQ,
-					 test_cmd_threads(dev, can_block),
-					 dev->udev_cmd_threads.cmd_list_lock);
+		scst_wait_event_interruptible_lock_irq(dev->udev_cmd_threads.cmd_list_waitQ,
+						       test_cmd_threads(dev, can_block),
+						       dev->udev_cmd_threads.cmd_list_lock);
 
 		dev_user_process_scst_commands(dev);
 
@@ -4053,8 +4053,8 @@ static int dev_user_cleanup_thread(void *arg)
 
 	spin_lock(&cleanup_lock);
 	while (!kthread_should_stop()) {
-		scst_wait_event_lock(cleanup_list_waitQ, test_cleanup_list(),
-				     cleanup_lock);
+		scst_wait_event_interruptible_lock(cleanup_list_waitQ, test_cleanup_list(),
+						   cleanup_lock);
 
 		/*
 		 * We have to poll devices, because commands can go from SCST

--- a/scst/src/scst_sysfs.c
+++ b/scst/src/scst_sysfs.c
@@ -470,8 +470,8 @@ static int sysfs_work_thread_fn(void *arg)
 	while (!kthread_should_stop()) {
 		if (one_time_only && !test_sysfs_work_list())
 			break;
-		scst_wait_event_lock(sysfs_work_waitQ, test_sysfs_work_list(),
-				     sysfs_work_lock);
+		scst_wait_event_interruptible_lock(sysfs_work_waitQ, test_sysfs_work_list(),
+						   sysfs_work_lock);
 		scst_process_sysfs_works();
 	}
 	spin_unlock(&sysfs_work_lock);

--- a/scst/src/scst_targ.c
+++ b/scst/src/scst_targ.c
@@ -4510,9 +4510,9 @@ int scst_init_thread(void *arg)
 
 	spin_lock_irq(&scst_init_lock);
 	while (!kthread_should_stop()) {
-		scst_wait_event_lock_irq(scst_init_cmd_list_waitQ,
-					 test_init_cmd_list(),
-					 scst_init_lock);
+		scst_wait_event_interruptible_lock_irq(scst_init_cmd_list_waitQ,
+						       test_init_cmd_list(),
+						       scst_init_lock);
 		scst_do_job_init();
 	}
 	spin_unlock_irq(&scst_init_lock);
@@ -6794,9 +6794,9 @@ int scst_tm_thread(void *arg)
 
 	spin_lock_irq(&scst_mcmd_lock);
 	while (!kthread_should_stop()) {
-		scst_wait_event_lock_irq(scst_mgmt_cmd_list_waitQ,
-					 test_mgmt_cmd_list(),
-					 scst_mcmd_lock);
+		scst_wait_event_interruptible_lock_irq(scst_mgmt_cmd_list_waitQ,
+						       test_mgmt_cmd_list(),
+						       scst_mcmd_lock);
 
 		while (!list_empty(&scst_active_mgmt_cmd_list)) {
 			int rc;
@@ -7610,8 +7610,8 @@ int scst_global_mgmt_thread(void *arg)
 
 	spin_lock_irq(&scst_mgmt_lock);
 	while (!kthread_should_stop()) {
-		scst_wait_event_lock_irq(scst_mgmt_waitQ, test_mgmt_list(),
-					 scst_mgmt_lock);
+		scst_wait_event_interruptible_lock_irq(scst_mgmt_waitQ, test_mgmt_list(),
+						       scst_mgmt_lock);
 
 		while (!list_empty(&scst_sess_init_list)) {
 			sess = list_first_entry(&scst_sess_init_list,


### PR DESCRIPTION
This patch changes the processing threads to use INTERRUPTIBLE sleep states in the scst_wait_event_...() functions. This aims to avoid warnings from the hung task detection checker and to prevent unnecessary load counting.

Fixes: d8894cbd1157 ("scst.h: Refactor wait_event_locked() to enhance usability and clarity")