### PR TITLE
scst: Confirm percpu refs has scheduled and switched to atomic

### DIFF
--- a/.github/workflows/checkpatch_pull.yml
+++ b/.github/workflows/checkpatch_pull.yml
@@ -30,6 +30,7 @@ jobs:
             UNKNOWN_COMMIT_ID
             NO_AUTHOR_SIGN_OFF
             COMMIT_LOG_USE_LINK
+            BAD_REPORTED_BY_LINK
             FILE_PATH_CHANGES
             SPDX_LICENSE_TAG
             LINUX_VERSION_CODE

--- a/.github/workflows/checkpatch_push.yml
+++ b/.github/workflows/checkpatch_push.yml
@@ -35,6 +35,7 @@ jobs:
             UNKNOWN_COMMIT_ID
             NO_AUTHOR_SIGN_OFF
             COMMIT_LOG_USE_LINK
+            BAD_REPORTED_BY_LINK
             FILE_PATH_CHANGES
             SPDX_LICENSE_TAG
             LINUX_VERSION_CODE

--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -1098,11 +1098,19 @@ static inline void percpu_ref_put(struct percpu_ref *ref)
 		ref->release(ref);
 }
 
-static inline void percpu_ref_kill(struct percpu_ref *ref)
+static inline void
+percpu_ref_kill_and_confirm(struct percpu_ref *ref, percpu_ref_func_t *confirm_kill)
 {
 	WARN_ON_ONCE(ref->dead);
 	ref->dead = true;
+	if (confirm_kill)
+		confirm_kill(ref);
 	percpu_ref_put(ref);
+}
+
+static inline void percpu_ref_kill(struct percpu_ref *ref)
+{
+	percpu_ref_kill_and_confirm(ref, NULL);
 }
 
 static inline void percpu_ref_resurrect(struct percpu_ref *ref)

--- a/scst/src/scst_priv.h
+++ b/scst/src/scst_priv.h
@@ -172,7 +172,6 @@ extern struct list_head scst_template_list;
 extern struct list_head scst_dev_list;
 extern struct list_head scst_dev_type_list;
 extern struct list_head scst_virtual_dev_type_list;
-extern wait_queue_head_t scst_dev_cmd_waitQ;
 
 extern const struct scst_cl_ops scst_no_dlm_cl_ops;
 extern const struct scst_cl_ops scst_dlm_cl_ops;


### PR DESCRIPTION
This patch replaces percpu_ref_kill() with percpu_ref_kill_and_confirm() to guarantee safe usage of references in atomic mode immediately afterwards.

This change ensures accurate checking of active commands following the initial reference killing.

Reported-by: Lev Vainblat <lev@zadarastorage.com>