### PR TITLE
Add support for iSCSI TargetAlias

### DIFF
--- a/iscsi-scst/README
+++ b/iscsi-scst/README
@@ -283,6 +283,10 @@ Each target subdirectory contains the following entries:
 
  - tid - TID of this target.
 
+ - alias - TargetAlias of this target.  If not set, it will default to the
+   empty string and no TargetAlias will be reported in LOGIN RESPONSE or iSNS
+   for this target.
+
 The "sessions" subdirectory contains the following attribute:
 
  - thread_pid - the process identifiers (PIDs) of the iscsird and iscsiwr
@@ -559,6 +563,7 @@ both iSCSI-SCST targets will look like:
 |       |   |-- NopInInterval
 |       |   |-- QueuedCommands
 |       |   |-- RspTimeout
+|       |   |-- alias
 |       |   |-- enabled
 |       |   |-- ini_groups
 |       |   |   `-- mgmt

--- a/iscsi-scst/usr/config.c
+++ b/iscsi-scst/usr/config.c
@@ -265,6 +265,32 @@ char *config_sep_string(char **pp)
 	return p;
 }
 
+/*
+ * Strip leading and trailing whitespace.
+ *
+ * Modifies the contents of the parameter string.
+ */
+char *config_strip_string(char *s)
+{
+	size_t size;
+	char *end;
+
+	size = strlen(s);
+
+	if (!size)
+		return s;
+
+	end = s + size - 1;
+	while (end >= s && isspace(*end))
+		end--;
+	*(end + 1) = '\0';
+
+	while (*s && isspace(*s))
+		s++;
+
+	return s;
+}
+
 static char *config_gets(char *buf, int size, const char *data, int *offset)
 {
 	int offs = *offset, i = 0;

--- a/iscsi-scst/usr/ctldev.c
+++ b/iscsi-scst/usr/ctldev.c
@@ -78,7 +78,12 @@ int kernel_target_create(struct target *target, u32 *tid, u32 cookie)
 	info.tid = (tid != NULL) ? *tid : 0;
 	info.cookie = cookie;
 
-	info.attrs_num = 2;
+	/*
+	 * ISCSI_PER_PORTAL_ACL_ATTR_NAME
+	 * ISCSI_TARGET_REDIRECTION_ATTR_NAME
+	 * ISCSI_TARGET_ALIAS_ATTR_NAME
+	 */
+	info.attrs_num = 3;
 
 	for (j = 0; j < session_key_last; j++) {
 		if (session_keys[j].show_in_sysfs)
@@ -115,6 +120,11 @@ int kernel_target_create(struct target *target, u32 *tid, u32 cookie)
 	kern_attrs[i].mode = 0644;
 	strlcpy(kern_attrs[i].name, ISCSI_TARGET_REDIRECTION_ATTR_NAME,
 		sizeof(ISCSI_TARGET_REDIRECTION_ATTR_NAME));
+	i++;
+
+	kern_attrs[i].mode = 0644;
+	strlcpy(kern_attrs[i].name, ISCSI_TARGET_ALIAS_ATTR_NAME,
+		sizeof(ISCSI_TARGET_ALIAS_ATTR_NAME));
 	i++;
 
 	for (j = 0; j < session_key_last; j++) {

--- a/iscsi-scst/usr/iscsid.c
+++ b/iscsi-scst/usr/iscsid.c
@@ -921,6 +921,8 @@ static void login_start(struct connection *conn)
 				return;
 			}
 		}
+		if (target->alias)
+			text_key_add(conn, "TargetAlias", target->alias);
 		log_debug(1, "target %s, sessions_count %d", target_name,
 			target->sessions_count);
 	}

--- a/iscsi-scst/usr/iscsid.h
+++ b/iscsi-scst/usr/iscsid.h
@@ -198,6 +198,7 @@ struct target {
 
 	unsigned int tgt_enabled:1;
 	unsigned int per_portal_acl:1;
+	unsigned int isns_registered:1;
 
 	unsigned int target_params[target_key_last];
 	unsigned int session_params[session_key_last];
@@ -353,6 +354,7 @@ extern int nl_open(void);
 
 /* config.c */
 extern char *config_sep_string(char **pp);
+extern char *config_strip_string(char *s);
 extern int config_parse_main(const char *data, u32 cookie);
 extern int config_load(const char *config_name);
 extern int config_target_create(u32 *tid, char *name);

--- a/iscsi-scst/usr/param.h
+++ b/iscsi-scst/usr/param.h
@@ -25,6 +25,7 @@
 #define ISCSI_TARGET_REDIRECTION_ATTR_NAME	"redirect"
 #define ISCSI_TARGET_REDIRECTION_VALUE_TEMP	"temp"
 #define ISCSI_TARGET_REDIRECTION_VALUE_PERM	"perm"
+#define ISCSI_TARGET_ALIAS_ATTR_NAME		"alias"
 
 struct iscsi_key;
 


### PR DESCRIPTION
This includes both support during iSCSI LOGIN and iSNS.

----
A couple of caveats...

### 1. checkpatch.pl
BTW, my local run of _checkpatch.pl_ was giving a warning:

```
WARNING:STRLCPY: Prefer strscpy over strlcpy - see: https://github.com/KSPP/linux/issues/89
#84: FILE: iscsi-scst/usr/ctldev.c:126:
+       strlcpy(kern_attrs[i].name, ISCSI_TARGET_ALIAS_ATTR_NAME,
```
However, since this is in **user-space** code rather than kernel, **strscpy** is not available!  I know we could have _checkpatch.pl_ always ignore `STRLCPY`, but I was wary about doing that as it'd do away with the check for kernel code too.

### 2. Windows iSNS Server
As documented [here](https://github.com/open-iscsi/target-isns/blob/master/documentation/iSNS-servers.md), the Windows iSNS server doesn't handle updates very well - now including alias updates.  OTOH, from https://learn.microsoft.com/en-us/windows-server/get-started/removed-deprecated-features-windows-server-2022
> The iSNS Server service has now been removed from Windows Server 2022