### PR TITLE
scst_mem: Port to Linux kernel v6.7

### DIFF
--- a/scst/src/scst_mem.h
+++ b/scst/src/scst_mem.h
@@ -138,7 +138,7 @@ static inline struct scatterlist *sgv_pool_sg(struct sgv_pool_obj *obj)
 	return obj->sg_entries;
 }
 
-int scst_sgv_pools_init(unsigned long mem_hwmark, unsigned long mem_lwmark);
+int __init scst_sgv_pools_init(unsigned long mem_hwmark, unsigned long mem_lwmark);
 void scst_sgv_pools_deinit(void);
 
 


### PR DESCRIPTION
Support for the following mm layer changes in the Linux kernel v6.7:

- c42d50aefd17 ("mm: shrinker: add infrastructure for dynamically allocating shrinker")