### PR TITLE
scst.h, scst, device handlers: Fix scst_replace_port_info

### DIFF
--- a/scst/include/scst.h
+++ b/scst/include/scst.h
@@ -2318,6 +2318,8 @@ struct scst_cmd {
 
 	uint32_t tgt_sn; /* SN set by target driver (for TM purposes) */
 
+	uint16_t tg_id; /* Only used during TYPE_DISK INQUIRY EVPD=0x83 */
+
 	uint8_t *cdb; /* Pointer on CDB. Points on cdb_buf for small CDBs. */
 	unsigned short cdb_len;
 	uint8_t cdb_buf[SCST_MAX_CDB_SIZE];
@@ -4522,6 +4524,13 @@ static inline bool scst_cmd_aborted_on_xmit(struct scst_cmd *cmd)
 static inline bool scst_get_cmd_dev_d_sense(struct scst_cmd *cmd)
 {
 	return (cmd->dev != NULL) ? cmd->dev->d_sense : 0;
+}
+
+/* Returns if command is INQUIRY EVPD=0x83 (device identification) */
+static inline bool scst_cmd_inquired_dev_ident(struct scst_cmd *cmd)
+{
+	return (cmd->cdb[0] == INQUIRY) && ((cmd->cdb[1] & 0x01/*EVPD*/) == 0x01) &&
+		(cmd->cdb[2] == 0x83/*device identification*/);
 }
 
 /*

--- a/scst/src/dev_handlers/scst_disk.c
+++ b/scst/src/dev_handlers/scst_disk.c
@@ -375,6 +375,15 @@ static enum scst_exec_res disk_exec(struct scst_cmd *cmd)
 	}
 
 	/*
+	 * If we are passing thru a INQUIRY VPD=0x83 (device identification) then
+	 * we will call scst_replace_port_info on success in scst_pass_through_cmd_done.
+	 * This will run in interrupt context, so we should not perform operations that
+	 * involve mutexes.  Call scst_lookup_tg_id here intead and save the output.
+	 */
+	if (unlikely(scst_cmd_inquired_dev_ident(cmd)))
+		cmd->tg_id = scst_lookup_tg_id(dev, tgt);
+
+	/*
 	 * For PC requests we are going to submit max_hw_sectors used instead
 	 * of max_sectors.
 	 */


### PR DESCRIPTION
`scst_pass_through_cmd_done` can run in interrupt context, and call `scst_replace_port_info`, which in turn was calling `scst_lookup_tg_id`. Since `scst_lookup_tg_id `does a `mutex_lock`, we should **not** call it from interrupt context.

The call path was added in https://github.com/SCST-project/scst/commit/e72eae316aeef2743cad70ed955e5b7f4ddca249 and could lead to:

```
BUG: scheduling while atomic: swapper/14/0/0x00000102

Preemption disabled at:
Call Trace:
[<ffffffffa1d1b146>] ___slab_alloc.constprop.0+0x4d6/0x750
 <IRQ>
 dump_stack_lvl+0x44/0x5c
 __schedule_bug.cold+0x80/0x8d
 __schedule+0x76c/0x860
 schedule+0x5a/0xb0
 schedule_preempt_disabled+0x14/0x30
 __mutex_lock.constprop.0+0x6ce/0x700
 scst_lookup_tg_id+0x19/0xa0 [scst]
 scst_pass_through_cmd_done+0x14f/0x2e0 [scst]
 scsi_end_async+0x44/0x70 [scst]
 __blk_mq_end_request+0x42/0x120
 scsi_end_request+0xdd/0x1c0 [scsi_mod]
 scsi_io_completion+0x56/0x880 [scsi_mod]
 ? scsi_device_unbusy+0x1e/0x90 [scsi_mod]
 blk_complete_reqs+0x3d/0x50
 __do_softirq+0xed/0x2fe
 ? ktime_get+0x38/0xa0
 do_softirq.part.0+0x95/0xd0
 </IRQ>
 <TASK>
 flush_smp_call_function_queue+0x78/0x90
 do_idle+0x177/0x2b0
 cpu_startup_entry+0x26/0x30
 start_secondary+0x130/0x150
 secondary_startup_64_no_verify+0xe5/0xeb
 </TASK>
```

(BTW, the fix suggested in this PR was influenced by the current location of `scst_pass_through_cmd_done` & `scst_lookup_tg_id`.)