### PR TITLE
scstadmin: Eliminate use of uninitialized value error

### DIFF
--- a/scstadmin/scstadmin.sysfs/scstadmin
+++ b/scstadmin/scstadmin.sysfs/scstadmin
@@ -2831,10 +2831,17 @@ sub applyConfigEnableTargets {
 				my $t_attributes;
 				($t_attributes, $errorString) = $SCST->targetAttributes($driver, $target);
 
-				if (defined($$t_attributes{'enabled'}) &&
-				    ($$t_attributes{'enabled'}->{'value'} != $$attributes{'enabled'})) {
-					setTargetAttribute($driver, $target, 'enabled', $$attributes{'enabled'});
-					$changes++;
+				if (defined($$attributes{'enabled'})) {
+					if (defined($$t_attributes{'enabled'}) &&
+					    ($$t_attributes{'enabled'}->{'value'} != $$attributes{'enabled'})) {
+						setTargetAttribute($driver, $target, 'enabled', $$attributes{'enabled'});
+						$changes++;
+					}
+				} else {
+					if ($driver ne 'copy_manager') {
+						setTargetAttribute($driver, $target, 'enabled', 0);
+						$changes++;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When running scstadmin to load a config file with a reduced the number of targets defined, the first time will generate an error
`Use of uninitialized value in numeric ne (!=) at /usr/local/sbin/scstadmin line 2834.
`
Rectify by checking for the uninitialized value, and taking appropriate steps (i.e disable the target).

It appears that the first time the command is run the target is supposed to get disabled, and fully removed when next run.

Here is an example of a failure when switching from 2 targets to 1 target (**demonstrates error, target not properly disabled**):
```
root@cluster1:~# scstadmin -noprompt -force -config /etc/scst.conf.1TARGET

Collecting current configuration: done.

-> Checking configuration file '/etc/scst.conf.1TARGET' for errors.
        -> Done, 0 warnings found.

-> Applying configuration.
        -> Removing LUN 0 from driver/target/group 'iscsi/iqn.2005-10.org.freenas.ctl:test2/security_group': done.
        -> Removing group 'security_group' from driver/target 'iscsi/iqn.2005-10.org.freenas.ctl:test2': done.

Collecting current configuration: done.

        -> Closing device 'extent2' using handler 'vdisk_fileio': done.
        -> Virtual target 'copy_manager_tgt' for driver 'copy_manager' is not in configuration. Use -force to remove it.
Use of uninitialized value in numeric ne (!=) at /usr/local/sbin/scstadmin line 2834.
        -> Disabling driver/target 'iscsi/iqn.2005-10.org.freenas.ctl:test2': done.
        -> Done, 4 change(s) made.

All done.
root@cluster1:~# cat /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test2/enabled
1
root@cluster1:~# scstadmin -noprompt -force -config /etc/scst.conf.1TARGET

Collecting current configuration: done.

-> Checking configuration file '/etc/scst.conf.1TARGET' for errors.
        -> Done, 0 warnings found.

-> Applying configuration.

Collecting current configuration: done.

        -> Virtual target 'copy_manager_tgt' for driver 'copy_manager' is not in configuration. Use -force to remove it.
        -> Removing virtual target 'iqn.2005-10.org.freenas.ctl:test2' from driver 'iscsi': done.
        -> Done, 1 change(s) made.

All done.
root@cluster1:~# cat /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test2/enabled
cat: '/sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test2/enabled': No such file or directory
root@cluster1:~#
```

and here is the same change steps executed with the updated `scstadmin` script (**no error**):
```
root@cluster1:~# ./scstadmin -noprompt -force -config /etc/scst.conf.1TARGET

Collecting current configuration: done.

-> Checking configuration file '/etc/scst.conf.1TARGET' for errors.
        -> Done, 0 warnings found.

-> Applying configuration.
        -> Removing LUN 0 from driver/target/group 'iscsi/iqn.2005-10.org.freenas.ctl:test2/security_group': done.
        -> Removing group 'security_group' from driver/target 'iscsi/iqn.2005-10.org.freenas.ctl:test2': done.

Collecting current configuration: done.

        -> Closing device 'extent2' using handler 'vdisk_fileio': done.
        -> Virtual target 'copy_manager_tgt' for driver 'copy_manager' is not in configuration. Use -force to remove it.
        -> Disabling driver/target 'iscsi/iqn.2005-10.org.freenas.ctl:test2': done.
        -> Done, 4 change(s) made.

All done.
root@cluster1:~# cat /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test2/enabled
0
root@cluster1:~# ./scstadmin -noprompt -force -config /etc/scst.conf.1TARGET

Collecting current configuration: done.

-> Checking configuration file '/etc/scst.conf.1TARGET' for errors.
        -> Done, 0 warnings found.

-> Applying configuration.

Collecting current configuration: done.

        -> Virtual target 'copy_manager_tgt' for driver 'copy_manager' is not in configuration. Use -force to remove it.
        -> Removing virtual target 'iqn.2005-10.org.freenas.ctl:test2' from driver 'iscsi': done.
        -> Done, 1 change(s) made.

All done.
root@cluster1:~# cat /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test2/enabled
cat: '/sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test2/enabled': No such file or directory
root@cluster1:~#
```