### PR TITLE
scst_vdisk: Fix check for blockio device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.sdtstub.S
 *~
 .cache.mk
+.cache/
 .ctf
 .depend_adm
 .depend_d

--- a/scst/src/dev_handlers/scst_vdisk.c
+++ b/scst/src/dev_handlers/scst_vdisk.c
@@ -1335,7 +1335,7 @@ static int vdisk_open_fd(struct scst_vdisk_dev *virt_dev, bool read_only)
 	 * For block devices, get the optimal I/O size from the block device
 	 * characteristics.
 	 */
-	if (virt_dev->bdev_handle && !virt_dev->opt_trans_len_set)
+	if (virt_dev->blockio && !virt_dev->opt_trans_len_set)
 		virt_dev->opt_trans_len = bdev_io_opt(virt_dev->bdev_handle->bdev) ? :
 					  virt_dev->opt_trans_len;
 


### PR DESCRIPTION
Suppress the following (false positive) Coverity complaint:

    CID 347415: (#1 of 1): Dereference after null check (FORWARD_NULL)
    var_deref_model: Passing null pointer virt_dev->bdev_handle to
    bdev_release_backport, which dereferences it