### PR TITLE
iscsi-scst: Add link_local parameter

### DIFF
--- a/iscsi-scst/README
+++ b/iscsi-scst/README
@@ -200,6 +200,9 @@ is /sys/kernel/scst_tgt/targets/iscsi. It has the following entries:
    iSCSI-SCST attributes before it starts accepting new connections. 0
    by default.
 
+ - link_local - if set, makes the response to an IPv6 SendTargets include
+   any link local addresses. Default is set.
+
  - open_state - read-only attribute, which allows to see if the user
    space part of iSCSI-SCST connected to the kernel part.
 
@@ -663,6 +666,7 @@ both iSCSI-SCST targets will look like:
 |       |   |       |-- reinstating
 |       |   |       `-- sid
 |       |   `-- tid
+|       |-- link_local
 |       |-- mgmt
 |       |-- open_state
 |       |-- trace_level

--- a/iscsi-scst/usr/event.c
+++ b/iscsi-scst/usr/event.c
@@ -644,6 +644,16 @@ static int handle_e_get_attr_value(int fd, const struct iscsi_kern_event *event)
 			goto out_free;
 		}
 		snprintf(res_str, sizeof(res_str), "%s", isns_entity_target_name);
+	} else if (strcasecmp(ISCSI_LINK_LOCAL_ATTR_NAME, pp) == 0)	{
+		if (target != NULL) {
+			log_error("Not NULL target %s for global attribute %s",
+				target->name, pp);
+			res = -EINVAL;
+			goto out_free;
+		}
+		snprintf(res_str, sizeof(res_str), "%d\n", send_targets_link_local);
+		if (send_targets_link_local != DEFAULT_SEND_TARGETS_LINK_LOCAL)
+			add_key_mark(res_str, sizeof(res_str), 0);
 	} else	{
 		log_error("Unknown attribute %s", pp);
 		res = -EINVAL;
@@ -1067,6 +1077,23 @@ static int handle_e_set_attr_value(int fd, const struct iscsi_kern_event *event)
 	} else if (strcasecmp(ISCSI_ISNS_ENTITY_ATTR_NAME, pp) == 0) {
 		pp = config_sep_string(&p);
 		strlcpy(isns_entity_target_name, pp, sizeof(isns_entity_target_name));
+	} else if (strcasecmp(ISCSI_LINK_LOCAL_ATTR_NAME, pp) == 0) {
+		if (target != NULL) {
+			log_error("Not NULL target %s for global attribute %s",
+				target->name, pp);
+			res = -EINVAL;
+			goto out_free;
+		}
+		pp = config_sep_string(&p);
+		if (strcmp(pp, "1") == 0)
+			send_targets_link_local = 1;
+		else if (strcmp(pp, "0") == 0)
+			send_targets_link_local = 0;
+		else {
+			log_error("Unknown value %s", pp);
+			res = -EINVAL;
+			goto out_free;
+		}
 	} else	{
 		log_error("Unknown attribute %s", pp);
 		res = -EINVAL;

--- a/iscsi-scst/usr/iscsi_scstd.c
+++ b/iscsi-scst/usr/iscsi_scstd.c
@@ -961,6 +961,9 @@ int main(int argc, char **argv)
 			S_IRUSR|S_IRGRP|S_IROTH|S_IWUSR, 0);
 	if (err != 0)
 		exit(err);
+	err = kernel_attr_add(NULL, ISCSI_LINK_LOCAL_ATTR_NAME, 0644, 0);
+	if (err != 0)
+		exit(err);
 
 	if ((ipc_fd = iscsi_adm_request_listen()) < 0) {
 		perror("Opening AF_LOCAL socket failed");

--- a/iscsi-scst/usr/iscsid.h
+++ b/iscsi-scst/usr/iscsid.h
@@ -307,6 +307,8 @@ extern void session_free(struct session *session);
 extern struct connection *conn_find(struct session *session, u16 cid);
 
 /* target.c */
+#define DEFAULT_SEND_TARGETS_LINK_LOCAL 1
+extern int send_targets_link_local;
 extern struct __qelem targets_list;
 extern int target_create(const char *name, struct target **out_target);
 extern void target_free(struct target *target);

--- a/iscsi-scst/usr/param.h
+++ b/iscsi-scst/usr/param.h
@@ -26,6 +26,7 @@
 #define ISCSI_TARGET_REDIRECTION_VALUE_TEMP	"temp"
 #define ISCSI_TARGET_REDIRECTION_VALUE_PERM	"perm"
 #define ISCSI_TARGET_ALIAS_ATTR_NAME		"alias"
+#define ISCSI_LINK_LOCAL_ATTR_NAME		"link_local"
 
 struct iscsi_key;
 

--- a/iscsi-scst/usr/target.c
+++ b/iscsi-scst/usr/target.c
@@ -33,6 +33,8 @@
 
 struct __qelem targets_list = LIST_HEAD_INIT(targets_list);
 
+int send_targets_link_local = DEFAULT_SEND_TARGETS_LINK_LOCAL;
+
 const char *iscsi_make_full_initiator_name(int per_portal_acl,
 	const char *initiator_name, const char *target_portal,
 	char *buf, int size)
@@ -203,6 +205,10 @@ static int is_addr_unspecified(char *addr)
 static void target_print_addr(struct connection *conn, char *addr, int family)
 {
 	char taddr[NI_MAXHOST + NI_MAXSERV + 5];
+
+	/* Maybe skip IPv6 link local addresses */
+	if (family == AF_INET6 && !send_targets_link_local && (strncasecmp(addr, "fe80:", 5) == 0))
+		return;
 
 	snprintf(taddr, sizeof(taddr),
 		(family == AF_INET) ? "%s:%d,1" : "[%s]:%d,1",


### PR DESCRIPTION
Add a `link_local` parameter to control whether an IPv6 `SendTargets` response includes link local addresses.  The default is to preserve the existing behavior and include them.

----
There could be several reasons why including link local addresses might **not** be desirable, incl:
- They are not routable
- Currently _open-iscsi_ has a bug whereby a link-local addresses included in SendTargets response may break the handling on the client, preventing discovery from working even if global IPv6 addresses are also available.  This will manifest if the response includes a zone-index naming an interface that is not available on the client.

Wrt the latter: over the years there have been various attempts to have this addressed from various directions  (e.g. in Ubuntu #[380663](https://bugs.launchpad.net/ubuntu/+source/open-iscsi/+bug/380663) or open-iscsi #[150](https://github.com/open-iscsi/open-iscsi/issues/150)), but since a satisfactory fix is not yet upstream, add `link_local` parameter to allow the issue to be avoided.

FYI, here's the failing _scst_/_open-iscsi_ interaction:
```
root@debian:~# iscsiadm -m discovery -t st -p fd37:beef:cafe::1
iscsiadm: Cannot resolve host fe80::f208:aa1a:e598:c5f3%enp0s9. getaddrinfo error: [Name or service not known]
iscsiadm: cannot resolve fe80::f208:aa1a:e598:c5f3%enp0s9
iscsiadm: failed to add default portal, ignoring target iqn.2005-10.org.freenas.ctl:test1
iscsiadm: failed to add target record
[fd37:beef:cafe::1]:3260,1 iqn.2005-10.org.freenas.ctl:test1
[fe80::50f3:e6fb:8b2e:cbd8%enp0s8]:3260,1 iqn.2005-10.org.freenas.ctl:test1
```
and again when `link_local` is set to 0
```
root@debian:~# iscsiadm -m discovery -t st -p fd37:beef:cafe::1
[fd37:beef:cafe::1]:3260,1 iqn.2005-10.org.freenas.ctl:test1
[fd37:beef:cafe::1]:3260,1 iqn.2005-10.org.freenas.ctl:test2
```

I didn't want to change the existing behavior by default (e.g. by changing the default value of `link_local`, or by just _**always**_ removing the link local addresses) in case the client issues are resolved in a future release.