### PR TITLE
scst_lib, scst_vdisk: Port to Linux kernel v6.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.orig
 *.sdtinfo.c
 *.sdtstub.S
+*.out
 *~
 .cache.mk
 .cache/

--- a/scst/include/scst.h
+++ b/scst/include/scst.h
@@ -5675,6 +5675,16 @@ int scst_scsi_exec_async(struct scst_cmd *cmd, void *data,
 int scst_get_file_mode(const char *path);
 bool scst_parent_dir_exists(const char *path);
 
+struct scst_bdev_descriptor {
+	struct block_device *bdev;
+	void *priv;
+};
+
+int scst_open_bdev_by_path(const char *path, blk_mode_t mode, void *holder,
+			   const struct blk_holder_ops *hops,
+			   struct scst_bdev_descriptor *bdev_desc);
+void scst_release_bdev(struct scst_bdev_descriptor *bdev_desc);
+
 struct scst_data_descriptor {
 	uint64_t sdd_lba;
 	uint64_t sdd_blocks;


### PR DESCRIPTION
Support for the following block layer changes in the Linux kernel v6.9:

- f3a608827d1f ("bdev: open block device as files")
- b1211a25c4fe ("bdev: make bdev_{release, open_by_dev}() private to block layer")