### PR TITLE
iscsi-scst: Add mechanism to restore target parameter to default

### DIFF
--- a/iscsi-scst/usr/param.c
+++ b/iscsi-scst/usr/param.c
@@ -279,7 +279,10 @@ int params_val_to_str(const struct iscsi_key *keys, int idx, unsigned int val,
 int params_str_to_val(const struct iscsi_key *keys, int idx, const char *str,
 		      unsigned int *val)
 {
-	if (keys[idx].ops->str_to_val)
+	if (!strcmp(":default:", str)) {
+		*val = keys[idx].local_def;
+		return 0;
+	} else if (keys[idx].ops->str_to_val)
 		return keys[idx].ops->str_to_val(str, val);
 	else
 		return 0;


### PR DESCRIPTION
Writing the string `:default:` to the _/sys_ entry will restore `local_def`

```
root@cluster1:~# cat /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test1/DataDigest
None
root@cluster1:~# echo CRC32C > /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test1/DataDigest
root@cluster1:~# cat /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test1/DataDigest
CRC32C
[key]

root@cluster1:~# echo ':default:' > /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test1/DataDigest
root@cluster1:~# cat /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test1/DataDigest
None
root@cluster1:~#
root@cluster1:~# cat /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test1/MaxRecvDataSegmentLength
1048576
root@cluster1:~# echo 8192 > /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test1/MaxRecvDataSegmentLength
root@cluster1:~# cat /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test1/MaxRecvDataSegmentLength
8192
[key]

root@cluster1:~# echo ':default:' > /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test1/MaxRecvDataSegmentLength
root@cluster1:~# cat /sys/kernel/scst_tgt/targets/iscsi/iqn.2005-10.org.freenas.ctl:test1/MaxRecvDataSegmentLength
1048576
```

Not attractive, but IMO the functionality is worthwhile.  If the user no longer wants to override a parameter, it seems preferrable to have a mechanism to reset it, rather than e.g. restart SCST.