### PR TITLE
scst/include/backport.h: Update backport for Linux kernel 6.6.23

### DIFF
--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -282,9 +282,10 @@ static inline void blkdev_put_backport(struct block_device *bdev, void *holder)
 
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 23)
 /*
  * See also commit e719b4d15674 ("block: Provide bdev_open_* functions") # v6.7.
+ * Also backported to 6.6.23 in commit dd0bd4291250
  */
 struct bdev_handle {
 	struct block_device *bdev;


### PR DESCRIPTION
The following was backported to Linux kernel [6.6.23](https://cdn.kernel.org/pub/linux/kernel/v6.x/ChangeLog-6.6.23)
- [dd0bd4291250](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=dd0bd4291250) (block: Provide bdev_open_* functions)