### PR TITLE
iscsi-scst: Add internal_portal parameter

### DIFF
--- a/iscsi-scst/README
+++ b/iscsi-scst/README
@@ -200,6 +200,13 @@ is /sys/kernel/scst_tgt/targets/iscsi. It has the following entries:
    iSCSI-SCST attributes before it starts accepting new connections. 0
    by default.
 
+ - internal_portal - May designate one or more existing portals as being
+   internal.  This will eliminate the need to supply a CHAP user/secret
+   during discovery or target login to any targets configured on those
+   portals.  This is particularly useful for internal targets used as
+   part of ALUA configuration.  Multiple addresses may be supplied,
+   separated by space characters.  Empty by default.
+
  - link_local - if set, makes the response to an IPv6 SendTargets include
    any link local addresses. Default is set.
 
@@ -552,6 +559,7 @@ both iSCSI-SCST targets will look like:
 |       |-- IncomingUser
 |       |-- OutgoingUser
 |       |-- enabled
+|       |-- internal_portal
 |       |-- iSNSServer
 |       |-- iqn.2006-10.net.vlnb:tgt
 |       |   |-- DataDigest

--- a/iscsi-scst/usr/iscsi_scstd.c
+++ b/iscsi-scst/usr/iscsi_scstd.c
@@ -964,6 +964,9 @@ int main(int argc, char **argv)
 	err = kernel_attr_add(NULL, ISCSI_LINK_LOCAL_ATTR_NAME, 0644, 0);
 	if (err != 0)
 		exit(err);
+	err = kernel_attr_add(NULL, ISCSI_INTERNAL_PORTAL_ATTR_NAME, 0644, 0);
+	if (err != 0)
+		exit(err);
 
 	if ((ipc_fd = iscsi_adm_request_listen()) < 0) {
 		perror("Opening AF_LOCAL socket failed");

--- a/iscsi-scst/usr/iscsid.h
+++ b/iscsi-scst/usr/iscsid.h
@@ -265,6 +265,7 @@ extern const char *get_error_str(int error);
 
 /* iscsid.c */
 extern int iscsi_enabled;
+extern char *internal_portal;
 
 extern int cmnd_execute(struct connection *conn);
 extern void cmnd_finish(struct connection *conn);

--- a/iscsi-scst/usr/param.h
+++ b/iscsi-scst/usr/param.h
@@ -21,6 +21,7 @@
 #define ISCSI_ENABLED_ATTR_NAME			"enabled"
 #define ISCSI_ISNS_ENTITY_ATTR_NAME			"isns_entity_name"
 #define ISCSI_ALLOWED_PORTAL_ATTR_NAME		"allowed_portal"
+#define ISCSI_INTERNAL_PORTAL_ATTR_NAME		"internal_portal"
 #define ISCSI_PER_PORTAL_ACL_ATTR_NAME		"per_portal_acl"
 #define ISCSI_TARGET_REDIRECTION_ATTR_NAME	"redirect"
 #define ISCSI_TARGET_REDIRECTION_VALUE_TEMP	"temp"


### PR DESCRIPTION
Add an `internal_portal` parameter to allow specified portals to bypass CHAP controls for both discovery and target login.  If not populated, then the current behavior will be preserved.

This is particularly useful for "internal" targets used as part of ALUA configuration (only presented on an internal, private portal).  It is envisaged that typical use would only be for those ALUA internal targets, and that `internal_portal` would only be set **once** (most likely to a single IP address, the private portal IP).  The main issue being addressed/avoided is that discovery auth is currently _global_.