### PR TITLE
scst_lib: Fix VPD inquiry handling on incorrect LUNs

### DIFF
--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -2094,7 +2094,7 @@ int scst_set_cmd_error(struct scst_cmd *cmd, int key, int asc, int ascq)
 		if (cmd->cdb[0] == REQUEST_SENSE)
 			res = scst_set_lun_not_supported_request_sense(cmd,
 				key, asc, ascq);
-		else if (cmd->cdb[0] == INQUIRY)
+		else if (cmd->cdb[0] == INQUIRY && !(cmd->cdb[1] & 0x01/*EVPD*/))
 			res = scst_set_lun_not_supported_inquiry(cmd);
 		else if (cmd->cdb[0] == REPORT_LUNS)
 			res = scst_set_lun_not_supported_report_luns(cmd);


### PR DESCRIPTION
When SCST receives an INQUIRY request for an incorrect LUN, it calls scst_set_lun_not_supported_inquiry(), which returns an inquiry buffer with a peripheral qualifier of 011b and a peripheral device type of 1Fh. However, for a VPD inquiry, it is unable to populate the remaining fields. According to SPC-6, if the device server cannot return the requested data, it should terminate with CHECK CONDITION.

Reported-by: Lev Vainblat <lev@zadarastorage.com>