### PR TITLE
backport.h, scst_tape.c, scst_lib.c: Fix build failures on RHEL9.5

### DIFF
--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -285,8 +285,8 @@ static inline void blkdev_put_backport(struct block_device *bdev, void *holder)
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0) &&			\
 	(LINUX_VERSION_CODE >> 8 != KERNEL_VERSION(6, 6, 0) >> 8 ||	\
 	 LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 23)) &&          \
-        (!defined(RHEL_RELEASE_CODE) ||                         \
-         RHEL_RELEASE_CODE -0 < RHEL_RELEASE_VERSION(9, 5))
+     (!defined(RHEL_RELEASE_CODE) ||                         \
+       RHEL_RELEASE_CODE -0 < RHEL_RELEASE_VERSION(9, 5))
 /*
  * See also commit e719b4d15674 ("block: Provide bdev_open_* functions") # v6.7, v6.6.23.
  */

--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -284,7 +284,9 @@ static inline void blkdev_put_backport(struct block_device *bdev, void *holder)
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 7, 0) &&			\
 	(LINUX_VERSION_CODE >> 8 != KERNEL_VERSION(6, 6, 0) >> 8 ||	\
-	 LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 23))
+	 LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 23)) &&          \
+        (!defined(RHEL_RELEASE_CODE) ||                         \
+         RHEL_RELEASE_CODE -0 < RHEL_RELEASE_VERSION(9, 5))
 /*
  * See also commit e719b4d15674 ("block: Provide bdev_open_* functions") # v6.7, v6.6.23.
  */

--- a/scst/src/dev_handlers/scst_tape.c
+++ b/scst/src/dev_handlers/scst_tape.c
@@ -174,7 +174,9 @@ static int tape_attach(struct scst_device *dev)
 			     ((dev->scsi_dev->scsi_level <= SCSI_2) ?
 			      ((dev->scsi_dev->lun << 5) & 0xe0) : 0),
 			     0 /* Mode Page 0 */,
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) ||            \
+       (!defined(RHEL_RELEASE_CODE) ||                          \
+        RHEL_RELEASE_CODE -0 >= RHEL_RELEASE_VERSION(9, 5))
 			     0 /* Sub Page */,
 #endif
 			     buffer, buffer_size,

--- a/scst/src/dev_handlers/scst_tape.c
+++ b/scst/src/dev_handlers/scst_tape.c
@@ -175,8 +175,8 @@ static int tape_attach(struct scst_device *dev)
 			      ((dev->scsi_dev->lun << 5) & 0xe0) : 0),
 			     0 /* Mode Page 0 */,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) ||            \
-       (!defined(RHEL_RELEASE_CODE) ||                          \
-        RHEL_RELEASE_CODE -0 >= RHEL_RELEASE_VERSION(9, 5))
+        (!defined(RHEL_RELEASE_CODE) ||                         \
+         RHEL_RELEASE_CODE -0 >= RHEL_RELEASE_VERSION(9, 5))
 			     0 /* Sub Page */,
 #endif
 			     buffer, buffer_size,

--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -6113,7 +6113,7 @@ EXPORT_SYMBOL(scst_open_bdev_by_path);
 void scst_release_bdev(struct scst_bdev_descriptor *bdev_desc)
 {
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0) &&            \
-       (!defined(RHEL_RELEASE_CODE) ||                         \
+        (!defined(RHEL_RELEASE_CODE) ||                         \
         RHEL_RELEASE_CODE -0 < RHEL_RELEASE_VERSION(9, 5))
 	struct bdev_handle *bdev_handle = bdev_desc->priv;
 

--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -6084,7 +6084,9 @@ int scst_open_bdev_by_path(const char *path, blk_mode_t mode, void *holder,
 			   const struct blk_holder_ops *hops,
 			   struct scst_bdev_descriptor *bdev_desc)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0) &&            \
+       (!defined(RHEL_RELEASE_CODE) ||                         \
+        RHEL_RELEASE_CODE -0 < RHEL_RELEASE_VERSION(9, 5))
 	struct bdev_handle *bdev_handle;
 
 	bdev_handle = bdev_open_by_path(path, mode, holder, hops);
@@ -6110,7 +6112,9 @@ EXPORT_SYMBOL(scst_open_bdev_by_path);
 
 void scst_release_bdev(struct scst_bdev_descriptor *bdev_desc)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 9, 0) &&            \
+       (!defined(RHEL_RELEASE_CODE) ||                         \
+        RHEL_RELEASE_CODE -0 < RHEL_RELEASE_VERSION(9, 5))
 	struct bdev_handle *bdev_handle = bdev_desc->priv;
 
 	if (bdev_handle)


### PR DESCRIPTION
Res on RHEL 9.5

There were 3 files that needed additional/updated conditional build checks for RHEL 9.5. 

These places already had some conditional checks, but more were needed since some of the upstream kernel changes have been pulled into the 5.14.0 kernel that RHEL 9.5 is using.

Files changed:

  scst/include/backport.h +285
  scst/src/scst_lib.c +6088 and +6116
  scst/src/dev_handlers/scst_tape.c +178

See the below compiler output before and after the fixes (intermediate failures are shown as I fixed them one by one):


```
[scst-3.9.0]# cat /etc/os-release
NAME="Red Hat Enterprise Linux"
VERSION="9.5 (Plow)"
ID="rhel"
ID_LIKE="fedora"
VERSION_ID="9.5"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Red Hat Enterprise Linux 9.5 (Plow)"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
HOME_URL="https://www.redhat.com/"
DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9"
BUG_REPORT_URL="https://issues.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_BUGZILLA_PRODUCT_VERSION=9.5
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.5"
[scst-3.9.0]# uname -r
5.14.0-503.11.1.el9_5.x86_64

[scst-3.9.0]#
[scst-3.9.0]# make scst_install

  ..<snip working files>..

make[3]: Entering directory '/usr/src/kernels/5.14.0-503.11.1.el9_5.x86_64'
  CC [M]  /root/scst-3.9.0/scst/src/scst_copy_mgr.o
In file included from /root/scst-3.9.0/scst/src/../include/scst.h:67,
                 from /root/scst-3.9.0/scst/src/scst_copy_mgr.c:17:
/root/scst-3.9.0/scst/src/../include/backport.h: In function ‘bdev_open_by_path_backport’:
/root/scst-3.9.0/scst/src/../include/backport.h:307:16: error: implicit declaration of function ‘blkdev_get_by_path’; did you mean ‘netdev_get_by_name’? [-Werror=implicit-function-declaration]
  307 |         bdev = blkdev_get_by_path(path, mode, holder, hops);
      |                ^~~~~~~~~~~~~~~~~~
      |                netdev_get_by_name
/root/scst-3.9.0/scst/src/../include/backport.h:307:14: warning: assignment to ‘struct block_device *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  307 |         bdev = blkdev_get_by_path(path, mode, holder, hops);
      |              ^
/root/scst-3.9.0/scst/src/../include/backport.h: In function ‘bdev_release_backport’:
/root/scst-3.9.0/scst/src/../include/backport.h:324:9: error: implicit declaration of function ‘blkdev_put’; did you mean ‘dev_put’? [-Werror=implicit-function-declaration]
  324 |         blkdev_put(handle->bdev, handle->holder);
      |         ^~~~~~~~~~
      |         dev_put
cc1: some warnings being treated as errors

  ..<snip ending>..

[scst-3.9.0]#

  ..<apply fix to backport.h>..

[scst-3.9.0]# make scst_install

  ..<snip working files>..

  CC [M]  /root/scst-3.9.0/scst/src/scst_lib.o
/root/scst-3.9.0/scst/src/scst_lib.c: In function ‘scst_open_bdev_by_path’:
/root/scst-3.9.0/scst/src/scst_lib.c:6090:23: error: implicit declaration of function ‘bdev_open_by_path’; did you mean ‘bdev_file_open_by_path’? [-Werror=implicit-function-declaration]
 6090 |         bdev_handle = bdev_open_by_path(path, mode, holder, hops);
      |                       ^~~~~~~~~~~~~~~~~
      |                       bdev_file_open_by_path
/root/scst-3.9.0/scst/src/scst_lib.c:6090:21: warning: assignment to ‘struct bdev_handle *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
 6090 |         bdev_handle = bdev_open_by_path(path, mode, holder, hops);
      |                     ^
/root/scst-3.9.0/scst/src/scst_lib.c:6094:38: error: invalid use of undefined type ‘struct bdev_handle’
 6094 |         bdev_desc->bdev = bdev_handle->bdev;
      |                                      ^~
/root/scst-3.9.0/scst/src/scst_lib.c: In function ‘scst_release_bdev’:
/root/scst-3.9.0/scst/src/scst_lib.c:6117:17: error: implicit declaration of function ‘bdev_release’; did you mean ‘dst_release’? [-Werror=implicit-function-declaration]
 6117 |                 bdev_release(bdev_handle);
      |                 ^~~~~~~~~~~~
      |                 dst_release

cc1: some warnings being treated as errors
  
  ..<snip ending>..

[scst-3.9.0]#

  ..<apply fix to scst_lib.h>..

[scst-3.9.0]# make scst_install

  ..<snip working files>..

In file included from ./include/scsi/scsi_cmnd.h:12,
                 from /root/scst-3.9.0/scst/src/dev_handlers/../../include/scst.h:57,
                 from /root/scst-3.9.0/scst/src/dev_handlers/scst_tape.c:35:
./include/scsi/scsi_device.h:480:25: note: expected ‘int’ but argument is of type ‘struct scsi_mode_data *’
  480 |                     int retries, struct scsi_mode_data *data,
      |                     ~~~~^~~~~~~
/root/scst-3.9.0/scst/src/dev_handlers/scst_tape.c:173:14: error: too few arguments to function ‘scsi_mode_sense’
  173 |         rc = scsi_mode_sense(dev->scsi_dev,
      |              ^~~~~~~~~~~~~~~
In file included from ./include/scsi/scsi_cmnd.h:12,
                 from /root/scst-3.9.0/scst/src/dev_handlers/../../include/scst.h:57,
                 from /root/scst-3.9.0/scst/src/dev_handlers/scst_tape.c:35:
./include/scsi/scsi_device.h:478:5: note: declared here
  478 | int scsi_mode_sense(struct scsi_device *sdev, int dbd, int modepage,
      |     ^~~~~~~~~~~~~~~

  ..<snip ending>..

[scst-3.9.0]#

  ..<apply fix to scst_tape.h>..

[scst-3.9.0]# make scst_install

  ..<snip all successful makes>..

[scst-3.9.0]# make scstadm_install

  ..<snip make output>..

for s in iscsi-scst qla2x00t; do                        \
  { if [ -n "" ]; then chr="chroot "; else chr=""; fi; if type systemctl >/dev/null 2>&1; then $chr systemctl disable "$s.service"; elif type chkconfig >/dev/null 2>&1; then $chr chkconfig --del "$s"; elif type update-rc.d >/dev/null 2>&1; then $chr update-rc.d -f "$s" remove; elif type rc-update >/dev/null 2>&1; then $chr rc-update del "$s"; elif type /usr/lib/lsb/remove_initd >/dev/null 2>&1; then $chr /usr/lib/lsb/remove_initd "$s"; fi; rm -f /etc/init.d/$s; } >/dev/null 2>&1;                \
done

If you want SCST to start automatically at boot time, run the following command:
systemctl enable scst.service

make[1]: Leaving directory '/root/scst-3.9.0/scstadmin'
[scst-3.9.0]# modprobe scst_vdisk
[scst-3.9.0]# modprobe iscsi_scst
[scst-3.9.0]# /etc/init.d/scst restart
Restarting SCSTSCST configuration file /etc/scst.conf missing

[scst-3.9.0]# lsmod | grep scst
scst_vdisk            172032  0
isert_scst             90112  4
iscsi_scst            208896  4 isert_scst
scst                 3964928  3 isert_scst,scst_vdisk,iscsi_scst
dlm                   380928  1 scst
rdma_cm               163840  1 isert_scst
ib_core               557056  4 isert_scst,rdma_cm,iw_cm,ib_cm
libcrc32c              12288  6 nf_conntrack,nf_nat,scst_vdisk,nf_tables,xfs,iscsi_scst
[scst-3.9.0]#
```