### PR TITLE
scst_lib: Move synchronize_rcu() calls out of loops to reduce overhead

### DIFF
--- a/scst/src/scst_priv.h
+++ b/scst/src/scst_priv.h
@@ -365,7 +365,6 @@ struct scst_acg *scst_find_acg(const struct scst_session *sess);
 void scst_check_reassign_sessions(void);
 
 int scst_sess_alloc_tgt_devs(struct scst_session *sess);
-void scst_sess_free_tgt_devs(struct scst_session *sess);
 struct scst_tgt_dev *scst_lookup_tgt_dev(struct scst_session *sess, u64 lun);
 void scst_nexus_loss(struct scst_tgt_dev *tgt_dev, bool queue_UA);
 


### PR DESCRIPTION
This patch refactors the code by accumulating the target devices into a temporary list and moving the synchronize_rcu() call outside of the loops. By doing so, we reduce the number of synchronize_rcu() calls to one, improving the efficiency of the cleanup process.

Fixes: https://github.com/SCST-project/scst/issues/229