### PR TITLE
iscsi-scst: Add transport name to sys entry for connection

### DIFF
--- a/iscsi-scst/kernel/conn.c
+++ b/iscsi-scst/kernel/conn.c
@@ -166,6 +166,25 @@ static ssize_t iscsi_conn_target_ip_show(struct kobject *kobj, struct kobj_attri
 static struct kobj_attribute iscsi_conn_target_ip_attr =
 	__ATTR(target_ip, 0444, iscsi_conn_target_ip_show, NULL);
 
+static ssize_t iscsi_conn_transport_show(struct kobject *kobj, struct kobj_attribute *attr,
+					 char *buf)
+{
+	int pos;
+	struct iscsi_conn *conn;
+
+	TRACE_ENTRY();
+
+	conn = container_of(kobj, struct iscsi_conn, conn_kobj);
+
+	pos = snprintf(buf, SCST_SYSFS_BLOCK_SIZE, "%s\n", conn->transport->name);
+
+	TRACE_EXIT_RES(pos);
+	return pos;
+}
+
+static struct kobj_attribute iscsi_conn_transport_attr =
+	__ATTR(transport, 0444, iscsi_conn_transport_show, NULL);
+
 static ssize_t iscsi_conn_cid_show(struct kobject *kobj, struct kobj_attribute *attr, char *buf)
 {
 	int pos;
@@ -284,6 +303,13 @@ restart:
 	if (res != 0) {
 		PRINT_ERROR("Unable create sysfs attribute %s for conn %s",
 			    iscsi_conn_target_ip_attr.attr.name, addr);
+		goto out_err;
+	}
+
+	res = sysfs_create_file(&conn->conn_kobj, &iscsi_conn_transport_attr.attr);
+	if (res != 0) {
+		PRINT_ERROR("Unable create sysfs attribute %s for conn %s",
+			    iscsi_conn_transport_attr.attr.name, addr);
 		goto out_err;
 	}
 


### PR DESCRIPTION
This will make it possible to distinguish `iSCSI-TCP` connections from `iSER` connections.

(It is possible that the _same_ interface/IP could be used for either.)