### PR TITLE
iscsi-scst: Add SHA256 and SHA3-256 support to CHAP

### DIFF
--- a/iscsi-scst/usr/Makefile
+++ b/iscsi-scst/usr/Makefile
@@ -23,7 +23,7 @@ cc-option = $(shell if $(CC) $(1) -Werror -S -o /dev/null -xc /dev/null \
 
 SRCS_D = iscsid.c iscsi_scstd.c conn.c session.c target.c message.c ctldev.c \
 		log.c chap.c event.c param.c config.c isns.c md5.c sha1.c \
-		misc.c
+		misc.c af_alg.c
 OBJS_D = $(SRCS_D:.c=.o)
 
 SRCS_ADM = iscsi_adm.c param.c

--- a/iscsi-scst/usr/af_alg.c
+++ b/iscsi-scst/usr/af_alg.c
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ *  af_alg - wrapper functions to call AF_ALG hash algorithms.
+ *
+ *  Copyright (C) 2025 Brian Meagher <brian.meagher@ixsystems.com>
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation, version 2
+ *  of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ */
+
+#include "af_alg.h"
+
+#include <sys/socket.h>
+#include <linux/if_alg.h>
+#include <string.h>
+#include <sys/param.h>
+#include <stdbool.h>
+
+int af_alg_init(const char *algorithm)
+{
+	int sockfd, datafd, algo_len;
+	struct sockaddr_alg sa = {
+		.salg_family = AF_ALG,
+		.salg_type = "hash",
+	};
+
+	algo_len = strlen(algorithm);
+	if (algo_len >= sizeof(sa.salg_name))
+		return -1;
+
+	sockfd = socket(AF_ALG, SOCK_SEQPACKET, 0);
+	if (sockfd == -1)
+		return -1;
+
+	/* +1 for null-terminator */
+	memcpy(sa.salg_name, algorithm, algo_len + 1);
+
+	if (bind(sockfd, (struct sockaddr *)&sa, sizeof(sa)) == -1) {
+		close(sockfd);
+		return -1;
+	}
+
+	datafd = accept(sockfd, NULL, 0);
+	if (datafd < 0) {
+		close(sockfd);
+		return -1;
+	}
+	close(sockfd);
+	return datafd;
+}
+
+void af_alg_update(int datafd, const void *data_in, size_t len)
+{
+	send(datafd, data_in, len, MSG_MORE);
+}
+
+ssize_t af_alg_final(int datafd, void *out, size_t len)
+{
+	char buffer[1024];
+	ssize_t bytes;
+
+	send(datafd, NULL, 0, 0);
+
+	bytes = recv(datafd, buffer, sizeof(buffer), 0);
+	memcpy(out, buffer, MIN(len, bytes));
+	return bytes;
+}
+
+bool af_alg_supported(char *alg)
+{
+	int sock = af_alg_init(alg);
+
+	if (sock < 0)
+		return false;
+	close(sock);
+	return true;
+}

--- a/iscsi-scst/usr/af_alg.h
+++ b/iscsi-scst/usr/af_alg.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+/*
+ *  Copyright (C) 2025 Brian Meagher <brian.meagher@ixsystems.com>
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation, version 2
+ *  of the License.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ */
+
+#ifndef SCST_AF_ALG_H
+#define SCST_AF_ALG_H
+
+#include <unistd.h>
+#include <stdbool.h>
+
+#define SCST_AF_ALG_SHA256_NAME  "sha256"
+#define SCST_AF_ALG_SHA3_256_NAME  "sha3-256"
+
+int af_alg_init(const char *algorithm);
+void af_alg_update(int datafd, const void *data_in, size_t len);
+ssize_t af_alg_final(int datafd, void *out, size_t len);
+bool af_alg_supported(char *alg);
+
+#endif


### PR DESCRIPTION
At the moment SCST contains support for 2 CHAP algorithms: MD5 and SHA1.  Linux LIO and open-iscsi both include these, as well as SHA256 and SHA3-256 (since 2019).

This PR adds SHA256 and SHA3-256 support to CHAP.  Since in SCST CHAP negotiation is performed by the userspace `iscsi-scstd` daemon, the PR uses the kernel userspace `AL_ALG` API to access the additional hash functions.

If configured for CHAP, on iSCSI login the client will present an ordered list of desired algorithms.  During this negotiation, if the client requests SHA256 or SHA3-256 we verify that the kernel supports the algorithm before agreeing to use it.

----
Did some testing using `open-iscsi` with target settings modified from the default, e.g.
```
node.session.auth.chap_algs = SHA256
node.session.auth.username = testuser1
node.session.auth.password = testpass1234
```
And adding for Mutual Auth
```
node.session.auth.username_in = testuser2
node.session.auth.password_in = testpass4321
```