### PR TITLE
iscsi-scstd: Fix redefinition of bool when building with GCC 15

### DIFF
--- a/iscsi-scst/Makefile
+++ b/iscsi-scst/Makefile
@@ -12,7 +12,7 @@ endif
 SHELL=/bin/bash
 
 SCST_DIR := $(shell echo "$$PWD")/../scst/src
-SBINDIR := $(PREFIX)/sbin
+SBINDIR ?= $(PREFIX)/sbin
 INITDIR := /etc/init.d
 RCDIR := /etc/rc.d
 MANDIR ?= $(PREFIX)/man

--- a/iscsi-scst/usr/iscsid.h
+++ b/iscsi-scst/usr/iscsid.h
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <netdb.h>
 #include <syslog.h>
+#include <stdbool.h>
 
 #include "types.h"
 #ifdef INSIDE_KERNEL_TREE
@@ -35,10 +36,6 @@
 #include "iscsi_hdr.h"
 #include "param.h"
 #include "misc.h"
-
-#ifndef bool
-typedef enum {false = 0, true} bool;
-#endif
 
 #define sBUG() assert(0)
 #define sBUG_ON(p) assert(!(p))

--- a/scst-dkms.spec.in
+++ b/scst-dkms.spec.in
@@ -148,7 +148,7 @@ for d in scst fcst iscsi-scst qla2x00t-32gbit/qla2x00-target scst_local srpt; do
 done
 
 %install
-export KVER=%{kversion} PREFIX=%{_prefix} MANDIR=%{_mandir} DEPMOD=true
+export KVER=%{kversion} PREFIX=%{_prefix} MANDIR=%{_mandir} SBINDIR=%{_sbindir} DEPMOD=true
 export BUILD_2X_MODULE=y CONFIG_SCSI_QLA_FC=y CONFIG_SCSI_QLA2XXX_TARGET=y
 for d in scst; do
     DESTDIR=%{buildroot} %{make} -C $d install

--- a/scst.spec.in
+++ b/scst.spec.in
@@ -142,7 +142,7 @@ done
 %install
 %{?kdir:export KDIR=%{kdir}}
 %{!?kdir:%{?kversion:export KVER=%{kversion}}}
-export PREFIX=%{_prefix} MANDIR=%{_mandir} DEPMOD=true
+export PREFIX=%{_prefix} MANDIR=%{_mandir} SBINDIR=%{_sbindir} DEPMOD=true
 export BUILD_2X_MODULE=y CONFIG_SCSI_QLA_FC=y CONFIG_SCSI_QLA2XXX_TARGET=y
 for d in scst; do
     DESTDIR=%{buildroot} %{make} -C $d install

--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -419,6 +419,14 @@ static inline void be32_to_cpu_array(u32 *dst, const __be32 *src, size_t len)
 #endif
 #endif
 
+/*
+ * See also commit 92676236917d ("Compiler Attributes: add support for
+ * __nonstring (gcc >= 8)") # v4.20.
+ */
+#ifndef __nonstring
+#define __nonstring
+#endif
+
 /* <linux/debugfs.h> */
 
 /*

--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -456,24 +456,24 @@ static int get_cdb_info_dyn_runtime_attr(struct scst_cmd *cmd,
 
 struct scst_sdbops {
 	uint8_t ops;		/* SCSI-2 op codes */
-	uint8_t devkey[16];	/* Key for every device type M,O,V,R
-				 * type_disk      devkey[0]
-				 * type_tape      devkey[1]
-				 * type_printer   devkey[2]
-				 * type_processor devkey[3]
-				 * type_worm      devkey[4]
-				 * type_cdrom     devkey[5]
-				 * type_scanner   devkey[6]
-				 * type_mod       devkey[7]
-				 * type_changer   devkey[8]
-				 * type_commdev   devkey[9]
-				 * type_reserv    devkey[A]
-				 * type_reserv    devkey[B]
-				 * type_raid      devkey[C]
-				 * type_enclosure devkey[D]
-				 * type_reserv    devkey[E]
-				 * type_reserv    devkey[F]
-				 */
+	uint8_t devkey[16] __nonstring;	/* Key for every device type M,O,V,R
+					 * type_disk      devkey[0]
+					 * type_tape      devkey[1]
+					 * type_printer   devkey[2]
+					 * type_processor devkey[3]
+					 * type_worm      devkey[4]
+					 * type_cdrom     devkey[5]
+					 * type_scanner   devkey[6]
+					 * type_mod       devkey[7]
+					 * type_changer   devkey[8]
+					 * type_commdev   devkey[9]
+					 * type_reserv    devkey[A]
+					 * type_reserv    devkey[B]
+					 * type_raid      devkey[C]
+					 * type_enclosure devkey[D]
+					 * type_reserv    devkey[E]
+					 * type_reserv    devkey[F]
+					 */
 	uint8_t info_lba_off;	/* LBA offset in cdb */
 	uint8_t info_lba_len;	/* LBA length in cdb */
 	uint8_t info_len_off;	/* length offset in cdb */

--- a/scstadmin/scstadmin.spec.in
+++ b/scstadmin/scstadmin.spec.in
@@ -56,7 +56,7 @@ export PREFIX=%{_prefix} DESTDIR=%{buildroot} MANDIR=%{buildroot}%{_mandir}
 %{make}
 
 %install
-export PREFIX=%{_prefix} DESTDIR=%{buildroot} MANDIR=%{buildroot}%{_mandir}
+export PREFIX=%{_prefix} DESTDIR=%{buildroot} MANDIR=%{buildroot}%{_mandir} SBINDIR=%{_sbindir}
 %{make} install_vendor
 %scstadmin_perl_process_packlist
 rm -rf %{buildroot}/var/adm/perl-modules/scst

--- a/scstadmin/scstadmin.sysfs/Makefile
+++ b/scstadmin/scstadmin.sysfs/Makefile
@@ -5,7 +5,7 @@ endif
 MODULE_VERSION = 1.0.0
 TOOL = scstadmin
 
-SBINDIR := $(PREFIX)/sbin
+SBINDIR ?= $(PREFIX)/sbin
 
 all: perl-module
 


### PR DESCRIPTION
GCC 15 (C23) now reserves bool/true/false, so the local typedef in iscsid.d breaks the build:

	error: cannot use keyword 'false' as enumeration constant
	error: expected ';', identifier or '(' before 'bool'

Include <stdbool.h> and drop the typedef.