### PR TITLE
iscsi-scst: use /run instead of /var/run

### DIFF
--- a/iscsi-scst/usr/iscsi_scstd.c
+++ b/iscsi-scst/usr/iscsi_scstd.c
@@ -979,7 +979,7 @@ int main(int argc, char **argv)
 		pid_t pid;
 		int fd;
 
-		fd = open("/var/run/iscsi-scstd.pid", O_WRONLY|O_CREAT, 0644);
+		fd = open("/run/iscsi-scstd.pid", O_WRONLY|O_CREAT, 0644);
 		if (fd < 0) {
 			log_error("unable to create pid file");
 			exit(1);

--- a/scstadmin/init.d/scst
+++ b/scstadmin/init.d/scst
@@ -102,7 +102,7 @@ start_daemon() {
 killproc() {
     exe=$(basename "$1")
     killall "$exe"
-    rm -f "/var/run/$exe.pid"
+    rm -f "/run/$exe.pid"
 }
 fi
 
@@ -275,8 +275,8 @@ stop_scst() {
 scst_status() {
         # Status has a slightly different meaning for the status command:
         # 0 - service running
-        # 1 - service dead, but /var/run/  pid  file exists
-        # 2 - service dead, but /var/lock/ lock file exists
+        # 1 - service dead, but /run/  pid  file exists
+        # 2 - service dead, but /run/lock/ lock file exists
         # 3 - service not running
 
         parse_scst_conf


### PR DESCRIPTION
When attempting to manage iscsi-scstd using a systemd service file, systemd warns:

PIDFile= references a path below legacy directory /var/run/, [...]

Change the pidfile path to be under /run instead.

/run has been in use as a replacement for /var/run for many years now (the original Debian proposal is from 2011). Most distributions symlink /var/run to /run, which means that this change should not have any adverse side effects for the vast majority of users.