### PR TITLE
scstadmin: Normalize SCST version parsing in SCST.pm

### DIFF
--- a/scstadmin/scstadmin.sysfs/scst-1.0.0/lib/SCST/SCST.pm
+++ b/scstadmin/scstadmin.sysfs/scst-1.0.0/lib/SCST/SCST.pm
@@ -333,12 +333,16 @@ sub new {
 
 	$self->{'debug'} = $debug;
 
-	my $scstVersion = $self->scstVersion();
+	my $rawVersion = $self->scstVersion();
 
 	die("Failed to obtain SCST version information. Are the SCST modules loaded?\n")
+	  if (!defined($rawVersion));
+
+	my ($scstVersion) = ($rawVersion =~ /(\d+\.\d+\.\d+)/);
+
+	die("Failed to parse SCST version from '$rawVersion'\n")
 	  if (!defined($scstVersion));
 
-	($scstVersion, undef) = split(/\-/, $scstVersion);
 	my($major, $minor, $release) = split(/\./, $scstVersion, 3);
 
 	($release, undef) = split(/\-/, $release) if ($release =~ /\-/);


### PR DESCRIPTION
scstadmin's version check assumed scstVersion() returns a bare "X.Y.Z". After changing the sysfs attribute it may return strings like "SCST version: 3.10.0-pre", which triggered a numeric warning and a false failure:

  Argument "SCST version: 3" isn't numeric in numeric gt (...)

Parse the version number from the raw string and ignore any prefix/suffix. If no version can be parsed, keep the existing failure path.

Fixes: https://github.com/SCST-project/scst/issues/296