### PR TITLE
iscsi-scst: Accept CRC32 or LIBCRC32C for crc32c() across kernels

### DIFF
--- a/iscsi-scst/kernel/Kconfig
+++ b/iscsi-scst/kernel/Kconfig
@@ -1,6 +1,6 @@
 config SCST_ISCSI
 	tristate "ISCSI Target"
-	depends on SCST && INET && LIBCRC32C
+	depends on SCST && INET && (LIBCRC32C || CRC32)
 	default SCST
 	help
 	  ISCSI target driver for SCST. The iSCSI protocol has been defined in

--- a/iscsi-scst/kernel/digest.c
+++ b/iscsi-scst/kernel/digest.c
@@ -26,7 +26,8 @@
 
 void digest_alg_available(int *val)
 {
-#if defined(CONFIG_LIBCRC32C_MODULE) || defined(CONFIG_LIBCRC32C)
+#if defined(CONFIG_LIBCRC32C_MODULE) || defined(CONFIG_LIBCRC32C) ||	\
+	defined(CONFIG_CRC32_MODULE) || defined(CONFIG_CRC32)
 	int crc32c = 1;
 #else
 	int crc32c = 0;
@@ -34,7 +35,7 @@ void digest_alg_available(int *val)
 
 	if ((*val & DIGEST_CRC32C) && !crc32c) {
 		PRINT_ERROR("CRC32C digest algorithm not available in kernel");
-		*val |= ~DIGEST_CRC32C;
+		*val &= ~DIGEST_CRC32C;
 	}
 }
 
@@ -65,7 +66,8 @@ static __be32 evaluate_crc32_from_sg(struct scatterlist *sg, int nbytes, uint32_
 	}
 #endif
 
-#if defined(CONFIG_LIBCRC32C_MODULE) || defined(CONFIG_LIBCRC32C)
+#if defined(CONFIG_LIBCRC32C_MODULE) || defined(CONFIG_LIBCRC32C) ||	\
+	defined(CONFIG_CRC32_MODULE) || defined(CONFIG_CRC32)
 	{
 		int pad_bytes = ((nbytes + 3) & -4) - nbytes;
 


### PR DESCRIPTION
Kernel v6.15+ removed LIBCRC32C and switched in-tree users to CRC32. Keep older kernels working by accepting either CRC32 or LIBCRC32C in Kconfig and preprocessor guards, so crc32c() usage compiles and links on both old and new kernels.