### PR TITLE
Update INSTALL.md and add which as a dependency

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,6 +4,7 @@
 
 If the following packages have not yet been installed, install these now:
 
+    which
     bzip2
     gcc
     kernel-devel or kernel-default-devel


### PR DESCRIPTION
Not having this dependency leads to this error:

░ The job identifier is 1246.
Jul 31 15:05:43 mp-scst-service scst[1184]: Loading and configuring SCSTAlready started Jul 31 15:05:43 mp-scst-service scst[1187]: Stopping SCST Jul 31 15:05:43 mp-scst-service scst[1198]: /etc/init.d/scst: line 149: which: command not found Jul 31 15:05:43 mp-scst-service systemd[1]: mp-scst.service: Control process exited, code=exited, status=1/FAILURE ░░ Subject: Unit process exited
░░ Defined-By: systemd
░░ Support: https://wiki.rockylinux.org/rocky/support

Stemming from the line: https://github.com/SCST-project/scst/blob/v3.9/scstadmin/init.d/scst#L162