### PR TITLE
Add systemd scst.service

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -90,6 +90,7 @@ install:
 	mv "$(DESTDIR)"/usr/man "$(DESTDIR)"/usr/share/man &&		\
 	dh_install &&							\
 	dh_installman &&						\
+	dh_installsystemd --name=scst --no-start &&			\
 	dh_installchangelogs &&						\
 	dh_compress &&							\
 	dh_fixperms &&							\

--- a/debian/scstadmin.install
+++ b/debian/scstadmin.install
@@ -1,4 +1,5 @@
 etc/init.d/scst
+lib/systemd/system/scst.service
 usr/sbin/scstadmin
 usr/share/perl/
 usr/lib/

--- a/scstadmin/Makefile
+++ b/scstadmin/Makefile
@@ -110,6 +110,12 @@ install install_vendor:
 	  mkdir -p $(DESTDIR)$(DEFAULTDIR);			\
 	  install -m 755 default/scst $(DESTDIR)$(DEFAULTDIR);	\
 	fi
+	# Install systemd service file
+	if [ -d systemd ]; then						\
+	  install -d $(DESTDIR)/lib/systemd/system;			\
+	  install -m 644 systemd/scst.service				\
+	    $(DESTDIR)/lib/systemd/system/scst.service;			\
+	fi
 	for s in iscsi-scst qla2x00t; do			\
 	  { $(call REMOVE_FN,$$s); } >/dev/null 2>&1;		\
 	done

--- a/scstadmin/systemd/scst.service
+++ b/scstadmin/systemd/scst.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=SCST - A Generic SCSI Target Subsystem
+Documentation=man:scstadmin(1) man:scst.conf(5)
+After=network-online.target local-fs.target
+Wants=network-online.target
+DefaultDependencies=no
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+EnvironmentFile=-/etc/default/scst
+ExecStart=/etc/init.d/scst start
+ExecStop=/etc/init.d/scst stop
+ExecReload=/etc/init.d/scst reload
+TimeoutStartSec=5min
+TimeoutStopSec=5min
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
With modern systemd (e.g. as contained by Debian Trixie) the lack of a `scst.service` file yields the following message on boot:

```
systemd-sysv-generator: SysV service '/etc/init.d/scst' lacks a native systemd unit file, automatically generating a unit file for compatibility.
systemd-sysv-generator: Please update package to include a native systemd unit file.
systemd-sysv-generator: ⚠️ This compatibility logic is deprecated, expect removal soon. ⚠️
```

Rectify by adding a unit file.