### PR TITLE
scst: Port to Linux kernel v6.19

### DIFF
--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -37,6 +37,7 @@
 #include <linux/jiffies.h>
 #include <linux/iocontext.h>
 #include <linux/kobject_ns.h>
+#include <linux/preempt.h>
 #include <linux/scatterlist.h>	/* struct scatterlist */
 #include <linux/shrinker.h>
 #include <linux/slab.h>		/* kmalloc() */
@@ -1021,6 +1022,15 @@ static inline void *vcalloc(size_t n, size_t size)
 {
 	return vzalloc(n * size);
 }
+#endif
+
+/* <linux/preempt.h> */
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+/*
+ * See also commit 15115830c887 ("preempt: Cleanup the macro maze a bit") # v5.11.
+ */
+#define in_hardirq()	(hardirq_count())
 #endif
 
 /* <linux/shrinker.h> */

--- a/scst/include/scst.h
+++ b/scst/include/scst.h
@@ -3987,7 +3987,7 @@ static inline bool scst_cmd_prelim_completed(struct scst_cmd *cmd)
 
 static inline enum scst_exec_context __scst_estimate_context(bool atomic)
 {
-	if (in_irq())
+	if (in_hardirq())
 		return SCST_CONTEXT_TASKLET;
 /*
  * We come here from many non reliable places, like the block layer, and don't

--- a/scst/src/scst_dlm.c
+++ b/scst/src/scst_dlm.c
@@ -1158,7 +1158,7 @@ static void scst_dlm_pr_write_unlock(struct scst_device *dev,
 
 static bool scst_dlm_reserved(struct scst_device *dev)
 {
-	WARN_ON_ONCE(in_irq() || irqs_disabled());
+	WARN_ON_ONCE(in_hardirq() || irqs_disabled());
 
 	get_lockspace(dev);
 	return dev->reserved_by || dev->pr_dlm->reserved_by_nodeid;
@@ -1171,7 +1171,7 @@ static void scst_dlm_res_lock(struct scst_device *dev,
 	struct scst_pr_dlm_data *const pr_dlm = dev->pr_dlm;
 	dlm_lockspace_t *ls;
 
-	WARN_ON_ONCE(in_irq() || irqs_disabled());
+	WARN_ON_ONCE(in_hardirq() || irqs_disabled());
 	memset(pr_lksb, 0, sizeof(*pr_lksb));
 	ls = get_lockspace(dev);
 	if (!ls)

--- a/scst/src/scst_no_dlm.c
+++ b/scst/src/scst_no_dlm.c
@@ -70,7 +70,7 @@ static void scst_no_dlm_res_lock(struct scst_device *dev,
 				 struct scst_lksb *pr_lksb)
 	__acquires(&dev->dev_lock)
 {
-	EXTRACHECKS_BUG_ON(in_irq() || irqs_disabled());
+	EXTRACHECKS_BUG_ON(in_hardirq() || irqs_disabled());
 	spin_lock_bh(&dev->dev_lock);
 }
 

--- a/scst/src/scst_targ.c
+++ b/scst/src/scst_targ.c
@@ -815,7 +815,7 @@ void scst_cmd_init_done(struct scst_cmd *cmd, enum scst_exec_context pref_contex
 	PRINT_BUFF_FLAG(TRACE_SCSI, "CDB", cmd->cdb, cmd->cdb_len);
 
 #ifdef CONFIG_SCST_EXTRACHECKS
-	if (unlikely((in_irq() || irqs_disabled())) &&
+	if (unlikely((in_hardirq() || irqs_disabled())) &&
 	    (pref_context == SCST_CONTEXT_DIRECT || pref_context == SCST_CONTEXT_DIRECT_ATOMIC)) {
 		PRINT_ERROR("Wrong context %d in IRQ from target %s, use SCST_CONTEXT_THREAD instead",
 			    pref_context, cmd->tgtt->name);
@@ -1632,7 +1632,7 @@ void scst_restart_cmd(struct scst_cmd *cmd, int status, enum scst_exec_context p
 		  status);
 
 #ifdef CONFIG_SCST_EXTRACHECKS
-	if ((in_irq() || irqs_disabled()) &&
+	if ((in_hardirq() || irqs_disabled()) &&
 	    (pref_context == SCST_CONTEXT_DIRECT || pref_context == SCST_CONTEXT_DIRECT_ATOMIC)) {
 		PRINT_ERROR("Wrong context %d in IRQ from target %s, use SCST_CONTEXT_THREAD instead",
 			    pref_context, cmd->tgtt->name);
@@ -1894,7 +1894,7 @@ void scst_rx_data(struct scst_cmd *cmd, int status, enum scst_exec_context pref_
 	cmd->cmd_hw_pending = 0;
 
 #ifdef CONFIG_SCST_EXTRACHECKS
-	if ((in_irq() || irqs_disabled()) &&
+	if ((in_hardirq() || irqs_disabled()) &&
 	    (pref_context == SCST_CONTEXT_DIRECT || pref_context == SCST_CONTEXT_DIRECT_ATOMIC)) {
 		PRINT_ERROR("Wrong context %d in IRQ from target %s, use SCST_CONTEXT_THREAD instead",
 			    pref_context, cmd->tgtt->name);
@@ -4452,7 +4452,7 @@ void scst_process_active_cmd(struct scst_cmd *cmd, bool atomic)
 	 * can safely ignore this warning since in_atomic() is used here only
 	 * for debugging purposes.
 	 */
-	EXTRACHECKS_BUG_ON(in_irq() || irqs_disabled());
+	EXTRACHECKS_BUG_ON(in_hardirq() || irqs_disabled());
 	EXTRACHECKS_WARN_ON((in_atomic() || in_interrupt()) && !atomic);
 
 	cmd->atomic = atomic;

--- a/srpt/src/ib_srpt.c
+++ b/srpt/src/ib_srpt.c
@@ -3531,7 +3531,7 @@ static int srpt_xfer_data(struct srpt_rdma_ch *ch,
 			scst_copy_sg(cmd, SCST_SG_COPY_FROM_TARGET);
 		}
 		scst_rx_data(cmd, SCST_RX_STATUS_SUCCESS,
-			     in_irq() ? SCST_CONTEXT_TASKLET :
+			     in_hardirq() ? SCST_CONTEXT_TASKLET :
 			     in_softirq() ? SCST_CONTEXT_DIRECT_ATOMIC :
 			     SCST_CONTEXT_DIRECT);
 		ret = 0;
@@ -3746,7 +3746,7 @@ static void srpt_tsk_mgmt_done(struct scst_mgmt_cmd *mcmnd)
 	pr_debug("tsk_mgmt_done for tag= %lld status=%d\n", ioctx->tsk_mgmt.tag,
 		 scst_mgmt_cmd_get_status(mcmnd));
 
-	WARN_ON(in_irq());
+	WARN_ON(in_hardirq());
 
 	srpt_set_cmd_state(ioctx, SRPT_STATE_MGMT_RSP_SENT);
 	WARN_ON(ioctx->state == SRPT_STATE_DONE);


### PR DESCRIPTION
Support for the following core changes in the Linux kernel v6.19:

  - 15115830c887 ("preempt: Cleanup the macro maze a bit")