### PR TITLE
scst_cmd_set_sn: remove lockless fast path

### DIFF
--- a/scst/include/scst.h
+++ b/scst/include/scst.h
@@ -756,12 +756,6 @@ struct scst_tgt_template {
 	unsigned enabled_attr_not_needed:1;
 
 	/*
-	 * True, if this target adapter can call scst_cmd_init_done() from
-	 * several threads at the same time.
-	 */
-	unsigned multithreaded_init_done:1;
-
-	/*
 	 * True, if this target driver supports T10-PI (DIF), i.e. sending and
 	 * receiving DIF PI tags. If false, SCST will not allow to add
 	 * DIF-enabled devices to this target driver's initiator groups.
@@ -2033,10 +2027,7 @@ struct scst_order_data {
 	atomic_t *cur_sn_slot;
 	atomic_t sn_slots[15];
 
-	/*
-	 * Used to serialized scst_cmd_init_done() if the corresponding
-	 * session's target template has multithreaded_init_done set
-	 */
+	/* Used to serialize scst_cmd_init_done(). */
 	spinlock_t init_done_lock;
 };
 
@@ -3590,8 +3581,6 @@ void scst_cmd_init_done(struct scst_cmd *cmd, enum scst_exec_context pref_contex
  * SCST done the command's preprocessing preprocessing_done() function
  * should be called. The second argument sets preferred command execution
  * context. See SCST_CONTEXT_* constants for details.
- *
- * See comment for scst_cmd_init_done() for the serialization requirements.
  */
 static inline void scst_cmd_init_stage1_done(struct scst_cmd *cmd,
 					     enum scst_exec_context pref_context, int set_sn)

--- a/scst_local/scst_local.c
+++ b/scst_local/scst_local.c
@@ -1352,7 +1352,6 @@ static struct scst_tgt_template scst_local_targ_tmpl = {
 	.name			= "scst_local",
 	.sg_tablesize		= 0xffff,
 	.xmit_response_atomic	= 1,
-	.multithreaded_init_done = 1,
 	.enabled_attr_not_needed = 1,
 	.tgtt_attrs		= scst_local_tgtt_attrs,
 	.tgt_attrs		= scst_local_tgt_attrs,


### PR DESCRIPTION
The lockless fast path for scst_cmd_set_sn() can cause commands to lockup in state EXEC_CHECK_SN when there are multiple scst_tgts accessing the same scst_device, for example two initiators connected to the two ports of a dual-port QLogic FC HBA in target mode both reading from the same shared disk.  The multithreaded_init_done value is too low-level for this; it does not take the higher-level configuration into account.

- Remove the lockless fast path.
- Remove multithreaded_init_done, which enabled/disabled the lockless fast path.
- Push the locking down into scst_cmd_set_sn(), which will now apply regardless of set_sn_on_restart_cmd, which matters for mixed-driver (e.g. iSCSI+qla2xxx) target-mode setups.
- Remove a bunch of comments explaining the rules for the lockless fast path.

Fixes: https://github.com/SCST-project/scst/issues/333