### PR TITLE
scst_lib: Use bdev_fput() to release bdev files

### DIFF
--- a/scst/src/scst_lib.c
+++ b/scst/src/scst_lib.c
@@ -6135,7 +6135,7 @@ void scst_release_bdev(struct scst_bdev_descriptor *bdev_desc)
 	struct file *bdev_file = bdev_desc->priv;
 
 	if (bdev_file)
-		fput(bdev_file);
+		bdev_fput(bdev_file);
 #endif
 
 	bdev_desc->bdev = NULL;


### PR DESCRIPTION
See also upstream commit 22650a99821d ("fs,block: yield devices early") # v6.9.