### PR TITLE
scstadmin: don't disable targets missing from the applied config without -force

### DIFF
--- a/scstadmin/scstadmin.sysfs/scstadmin
+++ b/scstadmin/scstadmin.sysfs/scstadmin
@@ -2838,9 +2838,15 @@ sub applyConfigEnableTargets {
 						$changes++;
 					}
 				} else {
-					if ($driver ne 'copy_manager') {
+					next if ($driver eq 'copy_manager');
+					next if (!defined($$t_attributes{'enabled'}) ||
+						 !$$t_attributes{'enabled'}->{'value'});
+					if ($deletions) {
 						setTargetAttribute($driver, $target, 'enabled', 0);
 						$changes++;
+					} else {
+						print "\t-> Driver/target '$driver/$target' is enabled ".
+						  "but not in configuration. Use -force to disable it.\n";
 					}
 				}
 			}


### PR DESCRIPTION
Fixes a regression introduced in f4f8da8 (#217, v3.9.0): applying a config file disables enabled targets that are not listed in the file at all, without `-force`.

Reproduction and analysis:

https://github.com/SCST-project/scst/pull/217#issuecomment-4977852242

The comparison code accidentally adds targets that are not mentioned in the config file to the parsed config and applyConfigEnableTargets() then disables them. On qla2x00t this flaps the FC port, and if the target was already disabled, the write fails and the whole apply aborts with FATAL.

With this patch such targets are disabled only with `-force` (like LUNs, groups and initiators), already disabled ones are skipped, and without `-force` only a message is printed. The `-force` use case from #217 works as before.