### PR TITLE
scst/include/backport.h: Fix backport for newer stable kernels

### DIFF
--- a/scst/include/backport.h
+++ b/scst/include/backport.h
@@ -1721,8 +1721,10 @@ static inline struct kmem_cache *kmem_cache_create_usercopy(const char *name,
  * See also commit e19e1b480ac7 ("add default_gfp() helper macro and use it
  * in the new *alloc_obj() helpers") # v7.0.
  */
+#ifndef default_gfp
 #define __default_gfp(a,...) a
 #define default_gfp(...) __default_gfp(__VA_ARGS__ __VA_OPT__(,) GFP_KERNEL)
+#endif
 #endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(7, 0, 0) &&			\
@@ -1797,6 +1799,7 @@ static inline struct kmem_cache *kmem_cache_create_usercopy(const char *name,
 /*
  * See also commit e4c8b46b924e ("slab: Introduce kmalloc_flex() and family") # v7.0.
  */
+#ifndef __alloc_flex
 #define __alloc_flex(KMALLOC, GFP, TYPE, FAM, COUNT)			\
 ({									\
 	const size_t __count = (COUNT);					\
@@ -1806,6 +1809,7 @@ static inline struct kmem_cache *kmem_cache_create_usercopy(const char *name,
 		__set_flex_counter(__obj_ptr->FAM, __count);		\
 	__obj_ptr;							\
 })
+#endif
 
 #define kmalloc_flex(VAR_OR_TYPE, FAM, COUNT, ...) \
 	__alloc_flex(kmalloc, default_gfp(__VA_ARGS__), typeof(VAR_OR_TYPE), FAM, COUNT)


### PR DESCRIPTION
`backport.h` defines `default_gfp()` and `__alloc_flex()` for `LINUX_VERSION_CODE < 7.0.0`, but stable kernels backported both, so the build fails:
```
backport.h:1724:9: error: "__default_gfp" redefined [-Werror]
backport.h:1725:9: error: "default_gfp" redefined [-Werror]
backport.h:1800:9: error: "__alloc_flex" redefined [-Werror]
```
**Affected:**
- `6.18.y >= v6.18.39` ([50c26b461b8e](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=50c26b461b8e), [2dca62902eb3](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=2dca62902eb3))
- `6.12.y >= v6.12.97` ([62554fc32b08](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=62554fc32b08), [5be0caeeb9a3](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=5be0caeeb9a3)).

Guarded with `#ifndef` rather than a version check, since stable branches pick these up at different points. Kernels without the macros are unaffected.